### PR TITLE
[Feat] STAMPIT-58 기본버튼 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Common/DefaultButton.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/DefaultButton.swift
@@ -82,6 +82,7 @@ extension DefaultButton {
         case confirm
         case send
         case enter
+        case modify
 
         var title: String {
             switch self {
@@ -93,6 +94,8 @@ extension DefaultButton {
                 "전달하기"
             case .enter:
                 "입장하기"
+            case .modify:
+                "수정하기"
             }
         }
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Common/DefaultButton.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/DefaultButton.swift
@@ -1,0 +1,99 @@
+//
+//  DefaultButton.swift
+//  StampIt-Project
+//
+//  Created by 곽다은 on 6/7/25.
+//
+
+import UIKit
+
+final class DefaultButton: UIButton {
+
+    // MARK: - Properties
+
+    var type: ButtonType
+
+    // MARK: - Init
+
+    init(type: ButtonType) {
+        self.type = type
+        super.init(frame: .zero)
+        setStyles()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Set Styles
+
+    private func setStyles() {
+        setConfiguration(with: type)
+        setCornerRadius()
+        stateUpdateHandler()
+    }
+
+    /// Configuration 설정
+    private func setConfiguration(with type: ButtonType) {
+        var config = UIButton.Configuration.filled()
+
+        // attributedTitle
+        let attributed = AttributedString(type.title)
+        var container = AttributeContainer()
+        container.font = .pretendard(size: 18, weight: .semibold)
+        let styled = attributed.settingAttributes(container)
+        config.attributedTitle = styled
+
+        // color
+        config.baseBackgroundColor = .red400
+        config.baseForegroundColor = .white
+
+        configuration = config
+    }
+
+    /// 버튼의 state가 변경될 때마다 호출되는 handler 정의
+    private func stateUpdateHandler() {
+        configurationUpdateHandler = { button in
+            var updated = button.configuration
+            updated?.baseBackgroundColor = button.isEnabled ? .red400 : .gray50
+            updated?.baseForegroundColor = button.isEnabled ? .white : .gray300
+            button.configuration = updated
+        }
+    }
+
+    /// cornerRadius 처리
+    ///
+    /// Configuration 사용에 따라 masksToBounds로 layer 마스킹
+    private func setCornerRadius() {
+        layer.cornerRadius = 12
+        layer.masksToBounds = true
+    }
+
+    /// 버튼 타입이 proceed일 때 마지막 단계인 경우 타이틀 변경
+    func updateProceed(isFinalStep: Bool) {
+        guard case .proceed(_) = type else { return }
+        setConfiguration(with: .proceed(isFinalStep: isFinalStep))
+    }
+}
+
+extension DefaultButton {
+    enum ButtonType {
+        case proceed(isFinalStep: Bool)
+        case confirm
+        case send
+        case enter
+
+        var title: String {
+            switch self {
+            case .proceed(let isFinalStep):
+                isFinalStep ? "시작하기" : "다음"
+            case .confirm:
+                "확인"
+            case .send:
+                "전달하기"
+            case .enter:
+                "입장하기"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-58
  

## 📌 변경 사항 및 이유
여러 VC에서 재사용할 수 있는 기본 버튼을 구현했습니다.


## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro - 활성화 | <img src = "https://github.com/user-attachments/assets/da816733-64c6-4d2a-9202-f66c5f17b5ba" width ="250">|
| iPhone 16 Pro - 비활성화 | <img src = "https://github.com/user-attachments/assets/77915103-15ec-40fb-b56a-7c7f2f250bad" width ="250">|


## 📌 PR Point
- 버튼 탭 피드백이 기본적으로 적용되어있는 Configuration을 사용하여 구현했습니다.
- proceed 타입 사용 시 updateProceed(isFinalStep:)로 타이틀을 '다음'에서 '시작하기'로 변경할 수 있습니다.


## 📌 참고 사항
- 테스트용 코드입니다. (컬러 에셋을 추가한 STAMPIT-59가 병합되기 전이면 실행이 안될겁니다 👀)
```swift
let defaultButton = DefaultButton(type: .proceed(isFinalStep: false))
view.addSubview(defaultButton)
defaultButton.isEnabled = false
defaultButton.snp.makeConstraints { make in
    make.top.equalToSuperview().inset(300)
    make.directionalHorizontalEdges.equalToSuperview().inset(16)
    make.height.equalTo(54)
}

DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
    defaultButton.updateProceed(isFinalStep: true)
}
```
