### PR TITLE
[Feat] STAMPIT-29 - AppleLogin 구현

### DIFF
--- a/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
+++ b/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 				CODE_SIGN_ENTITLEMENTS = "StampIt-Project/StampIt-Project.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 373K7546A3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StampIt-Project/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "스탬프잇";
@@ -369,7 +369,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-StampIt-Project";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-Stamp-It-Project";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -388,7 +388,7 @@
 				CODE_SIGN_ENTITLEMENTS = "StampIt-Project/StampIt-Project.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 373K7546A3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StampIt-Project/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "스탬프잇";
@@ -403,7 +403,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-StampIt-Project";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-Stamp-It-Project";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         let loginVC = DIContainer.shared.makeLoginViewController()
-        window?.rootViewController = loginVC
+        window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/StampIt-Project/StampIt-Project/Data/DataSources/AuthError.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/AuthError.swift
@@ -9,32 +9,41 @@ import Foundation
 
 enum AuthError: Error, LocalizedError {
     case presentingViewControllerNotFound
-    case googleSignInFailed(String)
+    case googleSignInFailed
     case tokenRetrievalFailed
-    case firebaseSignInFailed(String)
+    case firebaseSignInFailed
+    case appleSignInCanceled
     case appleSignInNotImplemented
-    case signOutFailed(String)
-    case accountDeletionFailed(String)
+    case appleSignInFailed
+    case signOutFailed
+    case accountDeletionFailed
     case userNotFound
+    case unknownError
     
     var errorDescription: String? {
         switch self {
         case .presentingViewControllerNotFound:
             return "화면을 찾을 수 없습니다."
-        case .googleSignInFailed(let message):
-            return "Google 로그인 실패: \(message)"
+        case .googleSignInFailed:
+            return "Google 로그인 실패했습니다."
         case .tokenRetrievalFailed:
             return "토큰을 가져올 수 없습니다."
-        case .firebaseSignInFailed(let message):
-            return "Firebase 로그인 실패: \(message)"
+        case .firebaseSignInFailed:
+            return "Firebase 로그인 실패에 실패했습니다."
+        case .appleSignInCanceled:
+            return "Apple 로그인이 취소되었습니다"
         case .appleSignInNotImplemented:
             return "Apple 로그인은 아직 구현되지 않았습니다."
-        case .signOutFailed(let message):
-            return "로그아웃 실패: \(message)"
-        case .accountDeletionFailed(let message):
-            return "계정 삭제 실패: \(message)"
+        case .signOutFailed:
+            return "로그아웃에 실패했습니다."
+        case .accountDeletionFailed:
+            return "계정 삭제에 실패했습니다."
         case .userNotFound:
             return "사용자를 찾을 수 없습니다."
+        case .unknownError:
+            return "알 수 없는 오류가 발생했습니다."
+        case .appleSignInFailed:
+            return "애플 인증 정보가 올바르지 않습니다."
         }
     }
 }

--- a/StampIt-Project/StampIt-Project/Data/DataSources/AuthManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/AuthManager.swift
@@ -63,7 +63,7 @@ final class AuthManager: NSObject,AuthManagerProtocol {
             }
             
             GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { result, error in
-                if let error = error {
+                if error != nil {
                     observer.onError(AuthError.googleSignInFailed)
                     return
                 }
@@ -80,7 +80,7 @@ final class AuthManager: NSObject,AuthManagerProtocol {
                 )
                 
                 Auth.auth().signIn(with: credential) { authResult, error in
-                    if let error = error {
+                    if error != nil {
                         observer.onError(AuthError.firebaseSignInFailed)
                     } else if let authResult = authResult {
                         observer.onNext(authResult)
@@ -162,7 +162,7 @@ final class AuthManager: NSObject,AuthManagerProtocol {
             }
             
             user.delete { error in
-                if let error = error {
+                if error != nil {
                     observer.onError(AuthError.accountDeletionFailed)
                 } else {
                     observer.onNext(())

--- a/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreError.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreError.swift
@@ -22,21 +22,21 @@ enum FirestoreError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .fetchFailed(let message):
-            return "데이터 조회 실패: \(message)"
+            return "데이터 조회에 실패했습니다. \(message)"
         case .createFailed(let message):
-            return "데이터 생성 실패: \(message)"
+            return "데이터 생성에 실패했습니다. \(message)"
         case .updateFailed(let message):
-            return "데이터 업데이트 실패: \(message)"
+            return "데이터 업데이트에 실패했습니다. \(message)"
         case .deleteFailed(let message):
-            return "데이터 삭제 실패: \(message)"
+            return "데이터 삭제에 실패했습니다. \(message)"
         case .documentNotFound:
             return "문서를 찾을 수 없습니다"
         case .encodingFailed(let message):
-            return "데이터 인코딩 실패: \(message)"
+            return "데이터 인코딩을 실패했습니다. \(message)"
         case .decodingFailed(let message):
-            return "데이터 디코딩 실패: \(message)"
+            return "데이터 디코딩을 실패했습니다. \(message)"
         case .networkError(let message):
-            return "네트워크 오류: \(message)"
+            return "네트워크 오류가 발생했습니다. \(message)"
         case .unknownError:
             return "알 수 없는 오류가 발생했습니다."
         }

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
@@ -288,8 +288,10 @@ final class AuthRepository: AuthRepositoryProtocol {
     private func mapToRepositoryError(_ error: Error) -> RepositoryError {
         if let authError = error as? AuthError {
             switch authError {
-            case .googleSignInFailed(let message), .firebaseSignInFailed(let message):
-                return .authenticationFailed(message)
+            case .googleSignInFailed:
+                return .authenticationFailed("Google 로그인에 실패했습니다")
+            case .firebaseSignInFailed:
+                return .authenticationFailed("Firebase 로그인에 실패했습니다")
             case .userNotFound:
                 return .userNotFound
             case .presentingViewControllerNotFound:

--- a/StampIt-Project/StampIt-Project/Domain/Entities/AuthDomainModel.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/AuthDomainModel.swift
@@ -17,7 +17,8 @@ struct AuthUser {
 
 /// 로그인 완료 결과
 struct LoginResult {
-    let user: StampIt_Project.User       // 도메인 모델
+    let authUser: AuthUser?              // 신규 사용자용 (Firebase 인증 정보)
+    let user: StampIt_Project.User?      // 기존 사용자용 (완전한 도메인 정보)
     let isNewUser: Bool                  // 신규 가입 여부
     let needsGroupSetup: Bool            // 그룹 설정 필요 여부
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/LoginUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/LoginUseCaseImpl.swift
@@ -15,12 +15,12 @@ final class LoginUseCase: LoginUseCaseProtocol {
     
     // MARK: - Properties
     private let authRepository: AuthRepositoryProtocol
-    private let randomNicknameProvider: (String) -> String  // ✅ 수정: userID 파라미터 추가
+    private let randomNicknameProvider: (String) -> String
     private let disposeBag = DisposeBag()
     
     // MARK: - Init
     init(authRepository: AuthRepositoryProtocol,
-         randomNicknameProvider: @escaping (String) -> String = LoginUseCase.generateSecureUniqueNickname) {  // ✅ 수정
+         randomNicknameProvider: @escaping (String) -> String = LoginUseCase.generateSecureUniqueNickname) {
         self.authRepository = authRepository
         self.randomNicknameProvider = randomNicknameProvider
     }
@@ -141,7 +141,7 @@ final class LoginUseCase: LoginUseCaseProtocol {
             let memberFirestore = MemberFirestore(
                 userId: loginResult.user.userID,
                 nickname: randomNickname,
-                joinedAt: Timestamp(date: now),  // ✅ Timestamp 변환
+                joinedAt: Timestamp(date: now),
                 isLeader: true
             )
             

--- a/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
@@ -379,26 +379,3 @@ final class LoginViewController: UIViewController {
         present(alert, animated: true)
     }
 }
-
-// MARK: - ASAuthorizationControllerDelegate
-// TODO: 애플로그인 작업에서 추가 구현 예정, 프레임만 구성함
-extension LoginViewController: ASAuthorizationControllerDelegate {
-    
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        // Apple 로그인 성공 처리는 ViewModel에서 담당
-        // 여기서는 UI 관련 처리만
-    }
-    
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        // Apple 로그인 실패 처리는 ViewModel에서 담당
-        // 여기서는 UI 관련 처리만
-    }
-}
-
-// MARK: - ASAuthorizationControllerPresentationContextProviding
-extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
-    
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return view.window!
-    }
-}


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: STAMPIT-29
제가 커밋 메시지에 헷갈려서 STAMPIT-28로 했는데 29입니다..!ㅠㅠ 잘못 작성했습니다..
  

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
AuthManager에서 데이터 전달 및 콜백 구현했습니다. 구글 로그인 구현하면서 나머지 프레임은 작성해서 AuthManager 위주로 봐주시면 될 것 같습니다. 그리고 AuthRepository에 Apple과 Google 로직이 똑같은데 나뉘어져있어서 중복 로직은 공통 메서드로 처리하도록 수정했습니다.


## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/0d17ad8e-ba23-4549-aedc-971b772fc3d7" width ="250">|


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
AuthManager, AuthRepository 보시고, 로직 동작 안되는 부분 있거나 개선 가능한 코드 있다면 말씀주시면 수정해두겠습니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
번들 아이디, GoogleService-info, info.plist 파일들 한 번씩 잘 확인해주시고, 애플-로그인 둘 중 하나라도 동작 안되는 경우 말씀 부탁드립니다. HotFix로 수정해서 올리겠습니다.