### PR TITLE
[Feat] STAMPIT-76 스탬프판 지그재그 로직 및 FireStore 테스트 완료

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
@@ -48,7 +48,8 @@ enum MyPage {
     }
     
     enum TableView {
-        static let sectionHeight: CGFloat = 45
+        static let headerHeightLow: CGFloat = 35
+        static let headerHeightHigh: CGFloat = 45
         static let cellHeight: CGFloat = 58
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
@@ -60,7 +60,10 @@ enum MyPage {
         static let slash: String = "/"
         
         // TODO: 로그인 연결시 삭제
+        // TODO: bindSticker() 내부에서 -> Sticker.maxStickers 변경
+        // TODO: Sticker 필드 maxStickers 확인
         static let totalStamp: String = "30"
+        static let totalStampNumber: Int = 30
         static let column: Int = 5
         static let fontSizeSmall: CGFloat = 14
         static let fontSizeMedium: CGFloat = 16

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
@@ -57,6 +57,8 @@ enum MyPage {
         static let completed: String = "완성한 스탬프판"
         static let unit: String = "개"
         static let slash: String = "/"
+        
+        // TODO: 로그인 연결시 삭제
         static let totalStamp: String = "30"
         static let column: Int = 5
         static let fontSizeSmall: CGFloat = 14

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
@@ -52,12 +52,13 @@ enum MyPage {
         static let cellHeight: CGFloat = 58
     }
     
-    enum Stamp {
+    enum StampBoard {
         static let collected: String = "내가 모은 스탬프"
         static let completed: String = "완성한 스탬프판"
         static let unit: String = "개"
         static let slash: String = "/"
         static let totalStamp: String = "30"
+        static let column: Int = 5
         static let fontSizeSmall: CGFloat = 14
         static let fontSizeMedium: CGFloat = 16
         static let vStackSpacing: CGFloat = 6

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampSummary.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampSummary.swift
@@ -17,34 +17,34 @@ final class StampSummary: UIView {
     private let stampVStackView = UIStackView().then {
         $0.axis = .vertical
         $0.alignment = .center
-        $0.spacing = MyPage.Stamp.vStackSpacing
+        $0.spacing = MyPage.StampBoard.vStackSpacing
     }
     
     /// 내가 모은 스탬프
     private let collectedStampTitle = UILabel().then {
-        $0.text = MyPage.Stamp.collected
-        $0.font = .pretendard(size: MyPage.Stamp.fontSizeMedium, weight: .regular)
+        $0.text = MyPage.StampBoard.collected
+        $0.font = .pretendard(size: MyPage.StampBoard.fontSizeMedium, weight: .regular)
         $0.textColor = .gray800
     }
     
     /// 내가 모은 스탬프 - 현재 개수
     private let currentStampLabel = UILabel().then {
         $0.text = "0"
-        $0.font = .pretendard(size: MyPage.Stamp.fontSizeMedium, weight: .bold)
+        $0.font = .pretendard(size: MyPage.StampBoard.fontSizeMedium, weight: .bold)
         $0.textColor = .gray800
     }
     
     /// 내가 모은 스탬프 - /
     private let slashLabel = UILabel().then {
-        $0.text = MyPage.Stamp.slash
-        $0.font = .pretendard(size: MyPage.Stamp.fontSizeMedium, weight: .regular)
+        $0.text = MyPage.StampBoard.slash
+        $0.font = .pretendard(size: MyPage.StampBoard.fontSizeMedium, weight: .regular)
         $0.textColor = .gray800
     }
 
     /// 내가 모은 스탬프 - 30
     private let totalStampLabel = UILabel().then {
-        $0.text = MyPage.Stamp.totalStamp
-        $0.font = .pretendard(size: MyPage.Stamp.fontSizeSmall, weight: .regular)
+        $0.text = MyPage.StampBoard.totalStamp
+        $0.font = .pretendard(size: MyPage.StampBoard.fontSizeSmall, weight: .regular)
         $0.textColor = .gray800
     }
     
@@ -58,20 +58,20 @@ final class StampSummary: UIView {
     private let boardVStackView = UIStackView().then {
         $0.axis = .vertical
         $0.alignment = .center
-        $0.spacing = MyPage.Stamp.vStackSpacing
+        $0.spacing = MyPage.StampBoard.vStackSpacing
     }
     
     /// 완성한 스탬프 판
     private let completedBoardTitle = UILabel().then {
-        $0.text = MyPage.Stamp.completed
-        $0.font = .pretendard(size: MyPage.Stamp.fontSizeMedium, weight: .regular)
+        $0.text = MyPage.StampBoard.completed
+        $0.font = .pretendard(size: MyPage.StampBoard.fontSizeMedium, weight: .regular)
         $0.textColor = .gray800
     }
     
     /// 완성한 스탬프 판 - N개
     private let totalBoardLabel = UILabel().then {
-        $0.text = "0\(MyPage.Stamp.unit)"
-        $0.font = .pretendard(size: MyPage.Stamp.fontSizeMedium, weight: .bold)
+        $0.text = "0\(MyPage.StampBoard.unit)"
+        $0.font = .pretendard(size: MyPage.StampBoard.fontSizeMedium, weight: .bold)
         $0.textColor = .gray800
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampSummary.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampSummary.swift
@@ -111,7 +111,7 @@ final class StampSummary: UIView {
         layer.shadowPath = path.cgPath
         layer.cornerRadius = 12
         layer.shadowColor = UIColor._000000.cgColor
-        layer.shadowOpacity = 0.1
+        layer.shadowOpacity = 0.15
         layer.shadowOffset = .zero
     }
     
@@ -162,7 +162,7 @@ final class StampSummary: UIView {
     private func setLayout() {
         hStackView.snp.makeConstraints {
             $0.edges.equalToSuperview().inset(12)
-            $0.height.equalTo(44)
+            $0.height.equalTo(50)
         }
         
         divider.snp.makeConstraints {

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampSummary.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampSummary.swift
@@ -40,7 +40,7 @@ final class StampSummary: UIView {
         $0.font = .pretendard(size: MyPage.StampBoard.fontSizeMedium, weight: .regular)
         $0.textColor = .gray800
     }
-
+    
     /// 내가 모은 스탬프 - 30
     private let totalStampLabel = UILabel().then {
         $0.text = MyPage.StampBoard.totalStamp
@@ -100,7 +100,7 @@ final class StampSummary: UIView {
     }
     
     // MARK: - Layout Subviews
-
+    
     override func layoutSubviews() {
         setShadow()
     }
@@ -114,7 +114,7 @@ final class StampSummary: UIView {
         layer.shadowOpacity = 0.1
         layer.shadowOffset = .zero
     }
-
+    
     // MARK: - Style Helper
     
     private func setStyle() {
@@ -156,7 +156,7 @@ final class StampSummary: UIView {
         ]
             .forEach { boardVStackView.addArrangedSubview($0) }
     }
-
+    
     // MARK: - Layout Helper
     
     private func setLayout() {
@@ -170,5 +170,14 @@ final class StampSummary: UIView {
             $0.width.equalTo(1)
             $0.center.equalToSuperview()
         }
+    }
+    
+    // MARK: Bind
+    
+    private func configureItem(with sticker: Sticker) {
+        // TODO: 로그인 연결시 sticker 데이터로 바인딩
+        currentStampLabel.text = "" // 내가 모은 스탬프 - 현재 개수
+        totalStampLabel.text = MyPage.StampBoard.totalStamp
+        totalBoardLabel.text = "" // 완성한 스탬프 판 - N개
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController+TableView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController+TableView.swift
@@ -9,7 +9,13 @@ import UIKit
 
 extension MyPageViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        MyPage.TableView.sectionHeight
+        let section = MyPageProfileSection.allCases[section]
+        switch section {
+        case .groupMember:
+            return MyPage.TableView.headerHeightLow
+        case .groupService:
+            return MyPage.TableView.headerHeightHigh
+        }
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -70,6 +70,9 @@ final class MyPageViewController: UIViewController {
         
         viewModel.state.stickers
             .bind(with: self) { owner, stickers in
+                
+                print("BIND STICKER: \n\(stickers)")
+                
                 self.updateUI(with: stickers)
             }.disposed(by: disposeBag)
     }
@@ -146,7 +149,7 @@ final class MyPageViewController: UIViewController {
         var snapshot = NSDiffableDataSourceSnapshot<StampBoardSection, StampBoardItem>()
         snapshot.appendSections([.defaultBoard])
         snapshot.appendItems(stickers, toSection: .defaultBoard)
-        stampBoardDataSource.apply(snapshot, animatingDifferences: true)
+        stampBoardDataSource.apply(snapshot, animatingDifferences: false)
     }
     
     // MARK: - Methods

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -142,23 +142,12 @@ final class MyPageViewController: UIViewController {
 
     // MARK: - Snapshot
     
-    private func updateUI(with item: [Sticker]) {
-        let allStamps = makeAllStamps(with: item)
+    private func updateUI(with stickers: [Sticker]) {
         var snapshot = NSDiffableDataSourceSnapshot<StampBoardSection, StampBoardItem>()
         snapshot.appendSections([.defaultBoard])
-        snapshot.appendItems(allStamps, toSection: .defaultBoard)
+        snapshot.appendItems(stickers, toSection: .defaultBoard)
         stampBoardDataSource.apply(snapshot, animatingDifferences: true)
     }
-    
-    private func makeAllStamps(with item: [Sticker]) -> [Sticker] {
-        let redItems = Array(repeating: StickerType.stampRed, count: item.count)
-        let grayItems = Array(repeating: StickerType.stampGray, count: 30 - item.count)
-        return (redItems + grayItems).map {
-            Sticker(stickerID: "0", title: "", description: "", imageURL: "", type: $0, createdAt: Date())
-        }
-    }
-    
-//    private func zigzagOrder
     
     // MARK: - Methods
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -24,6 +24,8 @@ final class MyPageViewModel: ViewModelProtocol {
     
     struct State {
         let user = BehaviorRelay<User?>(value: nil)
+        
+        // TODO: 로그인 연결시 목데이터 삭제
         let stickers = BehaviorRelay<[Sticker]>(value: DummyData.stamps)
         let tabType = BehaviorRelay<TabType>(value: .stampBoard)
     }
@@ -33,6 +35,11 @@ final class MyPageViewModel: ViewModelProtocol {
     let disposeBag = DisposeBag()
     let action = PublishRelay<Action>()
     var state = State()
+    
+    // TODO: 로그인 연결시 삭제
+    // TODO: bindSticker() 내부에서 -> Sticker.maxStickers 변경
+    // TODO: Sticker 필드 maxStickers 확인
+    private let totalCount = 30
     
     // MARK: - Initializer, Deinit, requiered
     
@@ -64,14 +71,43 @@ final class MyPageViewModel: ViewModelProtocol {
     }
     
     private func bindSticker() {
-        guard let user = state.user.value else { return }
+        guard let user = state.user.value else {
+            // TODO: 로그인 연결시 목데이터 삭제
+            self.state.stickers.accept(
+                self.makeZigzagOrder(from: self.state.stickers.value, columns: MyPage.StampBoard.column)
+            )
+            return
+        }
         myPageUseCase.fetchStickers(userId: user.userID)
             .subscribe(with: self) { owner, stickers in
-                self.state.stickers.accept(stickers)
+                self.state.stickers.accept(
+                    self.makeZigzagOrder(from: stickers, columns: MyPage.StampBoard.column)
+                )
             }.disposed(by: disposeBag)
+    }
+    
+    private func makeZigzagOrder(from stickers: [Sticker], columns: Int) -> [Sticker] {
+        let totalStickers: [Sticker] = (0..<self.totalCount).map { index in
+            if index < stickers.count {
+                return stickers[index]
+            } else {
+                return Sticker(stickerID: "\(UUID())", title: "", description: "", imageURL: "", type: .stampGray, createdAt: Date())
+            }
+        }
+        
+        let rows = stride(from: 0, to: totalStickers.count, by: columns)
+            .map {
+                Array(totalStickers[$0..<min($0 + columns, totalStickers.count)])
+            }
+        
+        let ordered = rows.enumerated().flatMap { (index, row) in
+            index.isMultiple(of: 2) ? row : row.reversed()
+        }
+        return ordered
     }
 }
 
+// TODO: 로그인 연결시 목데이터 삭제
 struct DummyData {
     static let stamps: [Sticker] = [
         Sticker(stickerID: "1", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
@@ -83,5 +119,13 @@ struct DummyData {
         Sticker(stickerID: "7", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
         Sticker(stickerID: "8", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
         Sticker(stickerID: "9", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "10", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "11", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "12", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "13", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "14", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "15", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "16", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
+        Sticker(stickerID: "17", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
     ]
 }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -24,9 +24,7 @@ final class MyPageViewModel: ViewModelProtocol {
     
     struct State {
         let user = BehaviorRelay<User?>(value: nil)
-        
-        // TODO: 로그인 연결시 목데이터 삭제
-        let stickers = BehaviorRelay<[Sticker]>(value: DummyData.stamps)
+        let stickers = BehaviorRelay<[Sticker]>(value: [])
         let tabType = BehaviorRelay<TabType>(value: .stampBoard)
     }
     
@@ -36,10 +34,6 @@ final class MyPageViewModel: ViewModelProtocol {
     let action = PublishRelay<Action>()
     var state = State()
     
-    // TODO: 로그인 연결시 삭제
-    // TODO: bindSticker() 내부에서 -> Sticker.maxStickers 변경
-    // TODO: Sticker 필드 maxStickers 확인
-    private let totalCount = 30
     
     // MARK: - Initializer, Deinit, requiered
     
@@ -71,23 +65,33 @@ final class MyPageViewModel: ViewModelProtocol {
     }
     
     private func bindSticker() {
-        guard let user = state.user.value else {
-            // TODO: 로그인 연결시 목데이터 삭제
-            self.state.stickers.accept(
-                self.makeZigzagOrder(from: self.state.stickers.value, columns: MyPage.StampBoard.column)
-            )
-            return
-        }
-        myPageUseCase.fetchStickers(userId: user.userID)
-            .subscribe(with: self) { owner, stickers in
-                self.state.stickers.accept(
-                    self.makeZigzagOrder(from: stickers, columns: MyPage.StampBoard.column)
-                )
-            }.disposed(by: disposeBag)
+        // TODO: Sticker 엔티티 수정완료시 변경
+//        guard let user = state.user.value else {
+//            self.state.stickers.accept(
+//                makeZigzagOrder(
+//                    from: self.state.stickers.value,
+//                    columns: MyPage.StampBoard.column
+//                )
+//            )
+//            return
+//        }
+        myPageUseCase.fetchStickers(userId: "testUser001")
+//        myPageUseCase.fetchStickers(userId: user.userID)
+            .subscribe(
+                with: self,
+                onNext: { owner, stickers in
+                    print("STICKER: \n\(stickers)")
+                    self.state.stickers.accept(
+                        self.makeZigzagOrder(from: stickers, columns: MyPage.StampBoard.column)
+                    )
+                }, onError: { owner, error in
+                    print("BIND ERROR: \(error.localizedDescription)")
+                }
+            ).disposed(by: disposeBag)
     }
     
     private func makeZigzagOrder(from stickers: [Sticker], columns: Int) -> [Sticker] {
-        let totalStickers: [Sticker] = (0..<self.totalCount).map { index in
+        let totalStickers: [Sticker] = (0..<MyPage.StampBoard.totalStampNumber).map { index in
             if index < stickers.count {
                 return stickers[index]
             } else {
@@ -105,27 +109,4 @@ final class MyPageViewModel: ViewModelProtocol {
         }
         return ordered
     }
-}
-
-// TODO: 로그인 연결시 목데이터 삭제
-struct DummyData {
-    static let stamps: [Sticker] = [
-        Sticker(stickerID: "1", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "2", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "3", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "4", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "5", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "6", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "7", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "8", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "9", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "10", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "11", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "12", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "13", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "14", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "15", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "16", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-        Sticker(stickerID: "17", title: "", description: "", imageURL: "", type: .stampRed, createdAt: Date()),
-    ]
 }


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
- STAMPIT-74 스탬프판 탭 비즈니스 로직 구현
   - STAMPIT-75 스탬프판 Repository, UseCase Protocol 선언
   - STAMPIT-76 스탬프판 지그재그 데이터 바인딩 로직 구현
  

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 로그인시 받아오는 스탬프 데이터로 바인딩
   - 지그재그 로직 구현
   - 요약 뷰 데이터 바인딩 (*임시)

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/4fc3e574-749d-4d5f-8484-91789e0416c3" width ="250">|


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 지그재그 스티커 부착 로직 및 데이터 바인딩
- 스탬프판 요약 뷰 데이터 바인딩
   - 참고 파일: `MyPageViewModel`, `MyPageViewController` 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 추가로 UI 피드백 수정후, 공통 네비게이션 바 작업 할 예정입니다.
- *임시: 스탬프판 관련 DB 수정시, 수정된 데이터 모델로요약 뷰에 바인딩하기 위해 추가 수정 되어야 합니다


## 📌 추가 테스트
- FireStore 연결하여 테스트 완료입니다! 아래 영상 확인해주세요 

<video src="https://github.com/user-attachments/assets/bc6e24bb-8fd2-434e-b1ae-487c496791f6" autoplay></video>
