### PR TITLE
[Feat] STAMPIT-82 - Sticker CURD 추가 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreManager.swift
@@ -23,14 +23,14 @@ protocol FirestoreManagerProtocol {
     func updateUser(_ user: UserFirestore) -> Observable<Void>
     func deleteUser(userId: String) -> Observable<Void>
     func updateUserNickname(userId: String, nickname: String, changedAt: Date) -> Observable<Void>
-
+    
     // Group 관련
     func fetchGroup(groupId: String) -> Observable<GroupFirestore>
     func createGroup(_ group: GroupFirestore) -> Observable<Void>
     func updateGroup(_ group: GroupFirestore) -> Observable<Void>
     func deleteGroup(groupId: String) -> Observable<Void>
     func updateGroupName(groupId: String, name: String, changedAt: Date) -> Observable<Void>
-
+    
     // Member 관련
     func fetchMembers(groupId: String) -> Observable<[MemberFirestore]>
     func addMember(groupId: String, member: MemberFirestore) -> Observable<Void>
@@ -44,7 +44,12 @@ protocol FirestoreManagerProtocol {
     
     // Sticker 관련
     func fetchStickers(userId: String, month: String) -> Observable<[StickerFirestore]>
+    func fetchStickersByPin(userId: String, pinNumber: Int) -> Observable<[StickerFirestore]>
+    func fetchStickerCount(userId: String) -> Observable<Int>
+    func fetchGroupStickers(groupId: String, month: String) -> Observable<[StickerFirestore]>
+    func fetchAllUserStickers(userId: String) -> Observable<[StickerFirestore]>
     func addSticker(_ sticker: StickerFirestore) -> Observable<Void>
+    func createStickerFromMission(userId: String, groupId: String, missionTitle: String, assignedBy: String, stickerType: String) -> Observable<StickerFirestore>
     
     // Invite 관련
     func fetchInvite(inviteCode: String) -> Observable<InviteFirestore>
@@ -374,7 +379,7 @@ extension FirestoreManager {
             return Disposables.create()
         }
     }
-
+    
     
     /// 그룹명 업데이트
     func updateGroupName(groupId: String, name: String, changedAt: Date) -> Observable<Void> {
@@ -571,6 +576,128 @@ extension FirestoreManager {
             let listener = self.stickersCollection
                 .whereField("userId", isEqualTo: userId)
                 .whereField("month", isEqualTo: month)
+                .order(by: "createdAt", descending: false)
+                .addSnapshotListener { querySnapshot, error in
+                    if let error = error {
+                        observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
+                        return
+                    }
+                    
+                    guard let documents = querySnapshot?.documents else {
+                        observer.onNext([])
+                        return
+                    }
+                    
+                    do {
+                        let stickers = try documents.compactMap { document -> StickerFirestore? in
+                            return try document.data(as: StickerFirestore.self)
+                        }
+                        observer.onNext(stickers)
+                    } catch {
+                        observer.onError(FirestoreError.decodingFailed(error.localizedDescription))
+                    }
+                }
+            
+            return Disposables.create {
+                listener.remove()
+            }
+        }
+    }
+    
+    /// 특정 사용자의 핀번호별 스티커 조회 (이전 스티커판용)
+    func fetchStickersByPin(userId: String, pinNumber: Int) -> Observable<[StickerFirestore]> {
+        return Observable.create { observer in
+            let listener = self.stickersCollection
+                .whereField("userId", isEqualTo: userId)
+                .whereField("pinNumber", isEqualTo: pinNumber)
+                .order(by: "createdAt", descending: false)
+                .addSnapshotListener { querySnapshot, error in
+                    if let error = error {
+                        observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
+                        return
+                    }
+                    
+                    guard let documents = querySnapshot?.documents else {
+                        observer.onNext([])
+                        return
+                    }
+                    
+                    do {
+                        let stickers = try documents.compactMap { document -> StickerFirestore? in
+                            return try document.data(as: StickerFirestore.self)
+                        }
+                        observer.onNext(stickers)
+                    } catch {
+                        observer.onError(FirestoreError.decodingFailed(error.localizedDescription))
+                    }
+                }
+            
+            return Disposables.create {
+                listener.remove()
+            }
+        }
+    }
+    
+    /// 특정 사용자의 현재 스티커 개수 조회 (핀번호 계산용)
+    func fetchStickerCount(userId: String) -> Observable<Int> {
+        return Observable.create { observer in
+            self.stickersCollection
+                .whereField("userId", isEqualTo: userId)
+                .getDocuments { querySnapshot, error in
+                    if let error = error {
+                        observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
+                        return
+                    }
+                    
+                    let count = querySnapshot?.documents.count ?? 0
+                    observer.onNext(count)
+                    observer.onCompleted()
+                }
+            
+            return Disposables.create()
+        }
+    }
+    
+    /// 특정 그룹의 모든 스티커 조회 (그룹 랭킹용-홈)
+    func fetchGroupStickers(groupId: String, month: String) -> Observable<[StickerFirestore]> {
+        return Observable.create { observer in
+            let listener = self.stickersCollection
+                .whereField("groupId", isEqualTo: groupId)
+                .whereField("month", isEqualTo: month)
+                .order(by: "createdAt", descending: false)
+                .addSnapshotListener { querySnapshot, error in
+                    if let error = error {
+                        observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
+                        return
+                    }
+                    
+                    guard let documents = querySnapshot?.documents else {
+                        observer.onNext([])
+                        return
+                    }
+                    
+                    do {
+                        let stickers = try documents.compactMap { document -> StickerFirestore? in
+                            return try document.data(as: StickerFirestore.self)
+                        }
+                        observer.onNext(stickers)
+                    } catch {
+                        observer.onError(FirestoreError.decodingFailed(error.localizedDescription))
+                    }
+                }
+            
+            return Disposables.create {
+                listener.remove()
+            }
+        }
+    }
+    
+    /// 특정 사용자의 모든 스티커 조회 (전체 기록용-마이페이지)
+    func fetchAllUserStickers(userId: String) -> Observable<[StickerFirestore]> {
+        return Observable.create { observer in
+            let listener = self.stickersCollection
+                .whereField("userId", isEqualTo: userId)
+                .order(by: "createdAt", descending: false)
                 .addSnapshotListener { querySnapshot, error in
                     if let error = error {
                         observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
@@ -619,9 +746,66 @@ extension FirestoreManager {
         }
     }
     
+    /// 스티커 정보 업데이트 (타입 변경 등): 해당 코드는 추가 기능 구현을 위해 미리 만들어둠
+        func updateSticker(_ sticker: StickerFirestore) -> Observable<Void> {
+            return Observable.create { observer in
+                do {
+                    try self.stickersCollection.document(sticker.documentID)
+                        .setData(from: sticker, merge: true) { error in
+                            if let error = error {
+                                observer.onError(FirestoreError.updateFailed(error.localizedDescription))
+                            } else {
+                                observer.onNext(())
+                                observer.onCompleted()
+                            }
+                        }
+                } catch {
+                    observer.onError(FirestoreError.encodingFailed(error.localizedDescription))
+                }
+                
+                return Disposables.create()
+            }
+        }
     
-    
-    
+    /// 미션 완료 시 자동 스티커 생성 (핀번호 자동 계산)
+    func createStickerFromMission(
+        userId: String,
+        groupId: String,
+        missionTitle: String,
+        assignedBy: String,
+        stickerType: String = "일반"
+    ) -> Observable<StickerFirestore> {
+        return fetchStickerCount(userId: userId)
+            .flatMap { [weak self] currentCount -> Observable<StickerFirestore> in
+                guard let self = self else {
+                    return Observable.error(FirestoreError.unknownError)
+                }
+                
+                let now = Date()
+                let calendar = Calendar.current
+                let month = String(format: "%04d-%02d",
+                                   calendar.component(.year, from: now),
+                                   calendar.component(.month, from: now))
+                
+                // 핀번호 계산: 1~30개 = 핀1, 31~60개 = 핀2, ...
+                let pinNumber = (currentCount / 30) + 1
+                
+                let sticker = StickerFirestore(
+                    stickerId: UUID().uuidString,
+                    userId: userId,
+                    groupId: groupId,
+                    month: month,
+                    type: stickerType,
+                    pinNumber: pinNumber,
+                    createdAt: Timestamp(date: now),
+                    missionTitle: missionTitle,
+                    assignedBy: assignedBy
+                )
+                
+                return self.addSticker(sticker)
+                    .map { _ in sticker }
+            }
+    }
 }
 
 // MARK: - Invite Operations
@@ -659,7 +843,6 @@ extension FirestoreManager {
     func createInvite(_ invite: InviteFirestore) -> Observable<Void> {
         return Observable.create { observer in
             do {
-                // ✅ Firestore 자동 Codable 인코딩
                 try self.invitesCollection.document(invite.documentID)
                     .setData(from: invite) { error in
                         if let error = error {


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-82
  STAMPIT-87

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
스티커 관련해서 CURD 수정했습니다. 마이페이지와 홈화면 미션에서 수정된 Manager 사용하시면 됩니다!

1. fetchStickersByPin - 특정 핀번호의 스티커만 필터링해서 조회 (1~30개=핀1, 31~60개=핀2/이전 스티커판 화면에서 과거 완성된 스티커판 보기)
2. fetchStickerCount - 사용자가 지금까지 모은 스티커 총 개수 반환(스티커 총 개수만 필요할 때 활용)
3. fetchGroupStickers -  특정 그룹의 모든 멤버 스티커를 월별로 조회(홈 화면 그룹 랭킹, 월간 리더보드 활용)
4. fetchAllUserStickers - 사용자의 모든 스티커를 시간순으로 조회 (월 구분 없이 스티커 상세정보 전체조회/ 마이페이지 전체 기록 보기, UI에 스티커 목록 표시할 때 활용)
🌟 createStickerFromMission - 미션 완료 시 스티커 자동 생성 + 핀번호 자동 계산
5. updateSticker - 기존 스티커 정보 수정 (타입 변경 등) -> 추가구현에 활용 예정
6. fetchStickers에 order: createdAt 추가 (기존 코드에서 수정함)


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
https://www.notion.so/CURD-21499818604680d18985c7aee34d3fd9
<<활용 방법 정리해뒀으니 참고해주시고 혹시 수정사항 있다면 말씀부탁드립니다!