### PR TITLE
[Fix] STAMPIT-95 - FirestoreManager Invite 수정, 자동 로그인 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -19,13 +19,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let hasOnboarded = UserDefaults.standard.bool(forKey: "hasOnboarded")
         let nav: UINavigationController
-
+        
         if hasOnboarded {
-            // 온보딩 완료 → 로그인 화면으로
-            let loginVC = DIContainer.shared.makeLoginViewController()
-            nav = UINavigationController(rootViewController: loginVC)
+            // 온보딩 끝났으면 → LaunchViewController(분기 전용)로 이동
+            let launchVC = LaunchViewController()
+            nav = UINavigationController(rootViewController: launchVC)
         } else {
-            // 온보딩 필요 → 온보딩 화면으로
+            // 온보딩 필요 → 온보딩 화면
             let onboardingVC = DIContainer.shared.makeOnboardingViewController()
             nav = UINavigationController(rootViewController: onboardingVC)
         }

--- a/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreManager.swift
@@ -57,6 +57,10 @@ protocol FirestoreManagerProtocol {
     func createStickerFromMission(userId: String, groupId: String, missionTitle: String, assignedBy: String, stickerType: String) -> Observable<StickerFirestore>
     
     // Invite 관련
+    func fetchGroupInviteCode(groupId: String) -> Observable<String>
+    func fetchGroupByInviteCode(inviteCode: String) -> Observable<GroupFirestore>
+    func switchUserGroup(userId: String, fromGroupId: String, toGroupId: String, userNickname: String) -> Observable<Void>
+    func fetchGroupMemberCount(groupId: String) -> Observable<Int>
     func fetchInvite(inviteCode: String) -> Observable<InviteFirestore>
     func createInvite(_ invite: InviteFirestore) -> Observable<Void>
     func deleteInvite(inviteCode: String) -> Observable<Void>
@@ -787,25 +791,25 @@ extension FirestoreManager {
     }
     
     /// 스티커 정보 업데이트 (타입 변경 등): 해당 코드는 추가 기능 구현을 위해 미리 만들어둠
-        func updateSticker(_ sticker: StickerFirestore) -> Observable<Void> {
-            return Observable.create { observer in
-                do {
-                    try self.stickersCollection.document(sticker.documentID)
-                        .setData(from: sticker, merge: true) { error in
-                            if let error = error {
-                                observer.onError(FirestoreError.updateFailed(error.localizedDescription))
-                            } else {
-                                observer.onNext(())
-                                observer.onCompleted()
-                            }
+    func updateSticker(_ sticker: StickerFirestore) -> Observable<Void> {
+        return Observable.create { observer in
+            do {
+                try self.stickersCollection.document(sticker.documentID)
+                    .setData(from: sticker, merge: true) { error in
+                        if let error = error {
+                            observer.onError(FirestoreError.updateFailed(error.localizedDescription))
+                        } else {
+                            observer.onNext(())
+                            observer.onCompleted()
                         }
-                } catch {
-                    observer.onError(FirestoreError.encodingFailed(error.localizedDescription))
-                }
-                
-                return Disposables.create()
+                    }
+            } catch {
+                observer.onError(FirestoreError.encodingFailed(error.localizedDescription))
             }
+            
+            return Disposables.create()
         }
+    }
     
     /// 미션 완료 시 자동 스티커 생성 (핀번호 자동 계산)
     func createStickerFromMission(
@@ -850,6 +854,106 @@ extension FirestoreManager {
 
 // MARK: - Invite Operations
 extension FirestoreManager {
+    
+    /// 그룹의 현재 초대 코드 조회 (그룹 설정용)
+    func fetchGroupInviteCode(groupId: String) -> Observable<String> {
+        return fetchGroup(groupId: groupId)
+            .map { group in
+                return group.inviteCode
+            }
+    }
+    
+    /// 초대 코드로 그룹 정보 조회 (초대 검증용)
+    func fetchGroupByInviteCode(inviteCode: String) -> Observable<GroupFirestore> {
+        return Observable.create { observer in
+            self.groupsCollection
+                .whereField("inviteCode", isEqualTo: inviteCode)
+                .limit(to: 1)
+                .getDocuments { querySnapshot, error in
+                    if let error = error {
+                        observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
+                        return
+                    }
+                    
+                    guard let documents = querySnapshot?.documents,
+                          let document = documents.first else {
+                        observer.onError(FirestoreError.documentNotFound)
+                        return
+                    }
+                    
+                    do {
+                        let group = try document.data(as: GroupFirestore.self)
+                        observer.onNext(group)
+                        observer.onCompleted()
+                    } catch {
+                        observer.onError(FirestoreError.decodingFailed(error.localizedDescription))
+                    }
+                }
+            
+            return Disposables.create()
+        }
+    }
+    
+    /// 사용자 그룹 변경 (트랜잭션)
+    func switchUserGroup(
+        userId: String,
+        fromGroupId: String,
+        toGroupId: String,
+        userNickname: String
+    ) -> Observable<Void> {
+        return Observable.create { observer in
+            let batch = Firestore.firestore().batch()
+            
+            // 1. 사용자 그룹 ID 업데이트
+            let userRef = self.usersCollection.document(userId)
+            batch.updateData(["groupId": toGroupId], forDocument: userRef)
+            
+            // 2. 기존 그룹에서 멤버 제거
+            let oldMemberRef = self.membersCollection(groupId: fromGroupId).document(userId)
+            batch.deleteDocument(oldMemberRef)
+            
+            // 3. 새 그룹에 멤버 추가
+            let newMemberRef = self.membersCollection(groupId: toGroupId).document(userId)
+            let memberData: [String: Any] = [
+                "userId": userId,
+                "nickname": userNickname,
+                "joinedAt": Timestamp(date: Date()),
+                "isLeader": false
+            ]
+            batch.setData(memberData, forDocument: newMemberRef)
+            
+            // 4. 커밋
+            batch.commit { error in
+                if let error = error {
+                    observer.onError(FirestoreError.updateFailed(error.localizedDescription))
+                } else {
+                    observer.onNext(())
+                    observer.onCompleted()
+                }
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+    /// 그룹 멤버 수 조회 (가입 제한 확인용)
+    func fetchGroupMemberCount(groupId: String) -> Observable<Int> {
+        return Observable.create { observer in
+            self.membersCollection(groupId: groupId)
+                .getDocuments { querySnapshot, error in
+                    if let error = error {
+                        observer.onError(FirestoreError.fetchFailed(error.localizedDescription))
+                        return
+                    }
+                    
+                    let count = querySnapshot?.documents.count ?? 0
+                    observer.onNext(count)
+                    observer.onCompleted()
+                }
+            
+            return Disposables.create()
+        }
+    }
     
     /// 초대 코드로 초대 정보 조회 (일회성)
     func fetchInvite(inviteCode: String) -> Observable<InviteFirestore> {

--- a/StampIt-Project/StampIt-Project/Data/Entities/GroupFirestore.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/GroupFirestore.swift
@@ -32,3 +32,16 @@ extension GroupFirestore {
         )
     }
 }
+
+extension Group {
+    func toFirestoreModel(name: String, inviteCode: String) -> GroupFirestore {
+        return GroupFirestore(
+            groupId: self.groupID,
+            name: name,
+            leaderId: self.leaderID,
+            inviteCode: inviteCode,
+            nameChangedAt: Timestamp(date: self.nameChangedAt),
+            createdAt: Timestamp(date: Date())
+        )
+    }
+}

--- a/StampIt-Project/StampIt-Project/Data/Entities/InviteFirestore.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/InviteFirestore.swift
@@ -27,7 +27,9 @@ extension InviteFirestore {
         return Invitation(
             groupID: self.groupId,
             createdBy: self.createdBy,
-            expiredAt: self.expiredAt?.dateValue() ?? Date.distantFuture
+            expiredAt: self.expiredAt?.dateValue() ?? Date.distantFuture,
+            inviteCode: self.inviteCode,
+            createdAt: self.createdAt.dateValue()
         )
     }
 }

--- a/StampIt-Project/StampIt-Project/Data/Entities/InviteFirestore.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/InviteFirestore.swift
@@ -33,3 +33,15 @@ extension InviteFirestore {
         )
     }
 }
+
+extension Invitation {
+    func toFirestoreModel() -> InviteFirestore {
+        return InviteFirestore(
+            inviteCode: self.inviteCode,
+            groupId: self.groupID,
+            createdBy: self.createdBy,
+            createdAt: Timestamp(date: self.createdAt),
+            expiredAt: self.expiredAt == Date.distantFuture ? nil : Timestamp(date: self.expiredAt)
+        )
+    }
+}

--- a/StampIt-Project/StampIt-Project/Data/Entities/MemberFirestore.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/MemberFirestore.swift
@@ -30,3 +30,14 @@ extension MemberFirestore {
         )
     }
 }
+
+extension Member {
+    func toFirestoreModel() -> MemberFirestore {
+        return MemberFirestore(
+            userId: self.userID,
+            nickname: self.nickname,
+            joinedAt: Timestamp(date: self.joinedAt),
+            isLeader: self.isLeader
+        )
+    }
+}

--- a/StampIt-Project/StampIt-Project/Data/Entities/UserFirestore.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/UserFirestore.swift
@@ -54,3 +54,17 @@ extension UserFirestore {
         )
     }
 }
+
+// Domain → Infrastructure 변환 메서드
+extension User {
+    func toFirestoreModel() -> UserFirestore {
+        return UserFirestore(
+            userId: self.userID,
+            nickname: self.nickname,
+            profileImage: self.profileImageURL,
+            groupId: self.groupID,
+            nicknameChangedAt: Timestamp(date: Date()), // 현재 시간으로 설정
+            createdAt: Timestamp(date: self.joinedGroupAt)
+        )
+    }
+}

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
@@ -53,7 +53,7 @@ final class AuthRepository: AuthRepositoryProtocol {
                 return Observable.error(repositoryError)
             }
     }
-
+    
     /// AuthDataResult를 LoginResult로 변환
     private func processAuthResult(_ authDataResult: AuthDataResult) -> Observable<LoginResult> {
         let firebaseUser = authDataResult.user
@@ -204,10 +204,10 @@ final class AuthRepository: AuthRepositoryProtocol {
     
     /// 신규 사용자, 그룹, 멤버를 트랜잭션으로 원자적 생성
     func createNewUserWithGroup(
-        user: UserFirestore,
-        group: GroupFirestore,
-        member: MemberFirestore,
-        invite: InviteFirestore
+        user: User,
+        group: Group,
+        member: Member,
+        invite: Invitation
     ) -> Observable<StampIt_Project.User> {
         return Observable.create { [weak self] observer in
             guard let _ = self else {
@@ -217,53 +217,62 @@ final class AuthRepository: AuthRepositoryProtocol {
             
             let batch = Firestore.firestore().batch()
             
+            // Domain → Infrastructure 변환
+            let userFirestore = user.toFirestoreModel()
+            let groupFirestore = group.toFirestoreModel(
+                name: "\(user.nickname)의 그룹",
+                inviteCode: invite.inviteCode
+            )
+            let memberFirestore = member.toFirestoreModel()
+            let inviteFirestore = invite.toFirestoreModel()
+            
             // 1. 유저
             let userDict: [String: Any] = [
-                "userId": user.userId,
-                "nickname": user.nickname,
-                "profileImage": user.profileImage as Any,
-                "groupId": user.groupId,
-                "nicknameChangedAt": user.nicknameChangedAt,
-                "createdAt": user.createdAt
+                "userId": userFirestore.userId,
+                "nickname": userFirestore.nickname,
+                "profileImage": userFirestore.profileImage as Any,
+                "groupId": userFirestore.groupId,
+                "nicknameChangedAt": userFirestore.nicknameChangedAt,
+                "createdAt": userFirestore.createdAt
             ]
-            let userRef = Firestore.firestore().collection("users").document(user.documentID)
+            let userRef = Firestore.firestore().collection("users").document(userFirestore.documentID)
             batch.setData(userDict, forDocument: userRef)
             
             // 2. 그룹
             let groupDict: [String: Any] = [
-                "groupId": group.groupId,
-                "name": group.name,
-                "leaderId": group.leaderId,
-                "inviteCode": group.inviteCode,
-                "nameChangedAt": group.nameChangedAt,
-                "createdAt": group.createdAt
+                "groupId": groupFirestore.groupId,
+                "name": groupFirestore.name,
+                "leaderId": groupFirestore.leaderId,
+                "inviteCode": groupFirestore.inviteCode,
+                "nameChangedAt": groupFirestore.nameChangedAt,
+                "createdAt": groupFirestore.createdAt
             ]
-            let groupRef = Firestore.firestore().collection("groups").document(group.documentID)
+            let groupRef = Firestore.firestore().collection("groups").document(groupFirestore.documentID)
             batch.setData(groupDict, forDocument: groupRef)
             
             // 3. 멤버
             let memberDict: [String: Any] = [
-                "userId": member.userId,
-                "nickname": member.nickname,
-                "joinedAt": member.joinedAt,
-                "isLeader": member.isLeader
+                "userId": memberFirestore.userId,
+                "nickname": memberFirestore.nickname,
+                "joinedAt": memberFirestore.joinedAt,
+                "isLeader": memberFirestore.isLeader
             ]
             let memberRef = Firestore.firestore()
                 .collection("groups")
-                .document(group.groupId)
+                .document(groupFirestore.groupId)
                 .collection("members")
-                .document(member.documentID)
+                .document(memberFirestore.documentID)
             batch.setData(memberDict, forDocument: memberRef)
             
             // 4. 초대 코드
             let inviteDict: [String: Any] = [
-                "inviteCode": invite.inviteCode,
-                "groupId": invite.groupId,
-                "createdBy": invite.createdBy,
-                "createdAt": invite.createdAt,
-                "expiredAt": invite.expiredAt as Any
+                "inviteCode": inviteFirestore.inviteCode,
+                "groupId": inviteFirestore.groupId,
+                "createdBy": inviteFirestore.createdBy,
+                "createdAt": inviteFirestore.createdAt,
+                "expiredAt": inviteFirestore.expiredAt as Any
             ]
-            let inviteRef = Firestore.firestore().collection("invites").document(invite.documentID)
+            let inviteRef = Firestore.firestore().collection("invites").document(inviteFirestore.documentID)
             batch.setData(inviteDict, forDocument: inviteRef)
             
             // 커밋
@@ -271,11 +280,7 @@ final class AuthRepository: AuthRepositoryProtocol {
                 if let error = error {
                     observer.onError(RepositoryError.dataError("신규 사용자 생성 실패: \(error.localizedDescription)"))
                 } else {
-                    let completeUser = user.toDomainModel(
-                        groupName: group.name,
-                        isLeader: true
-                    )
-                    observer.onNext(completeUser)
+                    observer.onNext(user)
                     observer.onCompleted()
                 }
             }

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
@@ -206,7 +206,8 @@ final class AuthRepository: AuthRepositoryProtocol {
     func createNewUserWithGroup(
         user: UserFirestore,
         group: GroupFirestore,
-        member: MemberFirestore
+        member: MemberFirestore,
+        invite: InviteFirestore
     ) -> Observable<StampIt_Project.User> {
         return Observable.create { [weak self] observer in
             guard let _ = self else {
@@ -227,7 +228,7 @@ final class AuthRepository: AuthRepositoryProtocol {
             ]
             let userRef = Firestore.firestore().collection("users").document(user.documentID)
             batch.setData(userDict, forDocument: userRef)
-
+            
             // 2. 그룹
             let groupDict: [String: Any] = [
                 "groupId": group.groupId,
@@ -239,7 +240,7 @@ final class AuthRepository: AuthRepositoryProtocol {
             ]
             let groupRef = Firestore.firestore().collection("groups").document(group.documentID)
             batch.setData(groupDict, forDocument: groupRef)
-
+            
             // 3. 멤버
             let memberDict: [String: Any] = [
                 "userId": member.userId,
@@ -253,6 +254,17 @@ final class AuthRepository: AuthRepositoryProtocol {
                 .collection("members")
                 .document(member.documentID)
             batch.setData(memberDict, forDocument: memberRef)
+            
+            // 4. 초대 코드
+            let inviteDict: [String: Any] = [
+                "inviteCode": invite.inviteCode,
+                "groupId": invite.groupId,
+                "createdBy": invite.createdBy,
+                "createdAt": invite.createdAt,
+                "expiredAt": invite.expiredAt as Any
+            ]
+            let inviteRef = Firestore.firestore().collection("invites").document(invite.documentID)
+            batch.setData(inviteDict, forDocument: inviteRef)
             
             // 커밋
             batch.commit { error in
@@ -270,7 +282,7 @@ final class AuthRepository: AuthRepositoryProtocol {
             return Disposables.create()
         }
     }
-
+    
     
     // MARK: - Private Methods
     /// 다양한 에러 타입을 RepositoryError로 매핑

--- a/StampIt-Project/StampIt-Project/Domain/Model/Invite.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Model/Invite.swift
@@ -11,4 +11,9 @@ struct Invitation {
     let groupID: String
     let createdBy: String
     let expiredAt: Date
+    
+    //추가
+    let inviteCode: String     
+    let createdAt: Date
+
 }

--- a/StampIt-Project/StampIt-Project/Domain/Repository/AuthRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/AuthRepository.swift
@@ -29,9 +29,9 @@ protocol AuthRepositoryProtocol {
     // MARK: - 트랜잭션 보장 메서드 (원자성 보장)
     // 중간에 실패 시 앞 단계 데이터가 DB에 반영될 위험을 막기 위해 트랜잭션 추가함
     func createNewUserWithGroup(
-        user: UserFirestore,
-        group: GroupFirestore,
-        member: MemberFirestore,
-        invite: InviteFirestore
+        user: User,
+        group: Group,
+        member: Member,
+        invite: Invitation
     ) -> Observable<StampIt_Project.User>
 }

--- a/StampIt-Project/StampIt-Project/Domain/Repository/AuthRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/AuthRepository.swift
@@ -31,6 +31,7 @@ protocol AuthRepositoryProtocol {
     func createNewUserWithGroup(
         user: UserFirestore,
         group: GroupFirestore,
-        member: MemberFirestore
+        member: MemberFirestore,
+        invite: InviteFirestore
     ) -> Observable<StampIt_Project.User>
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/LoginUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/LoginUseCaseImpl.swift
@@ -137,11 +137,20 @@ final class LoginUseCase: LoginUseCaseProtocol {
                 isLeader: true
             )
             
+            let inviteFirestore = InviteFirestore(
+                inviteCode: inviteCode,
+                groupId: groupId,
+                createdBy: authUser.uid,
+                createdAt: Timestamp(date: now),
+                expiredAt: nil // 영구 초대 코드
+            )
+            
             // 3. 트랜잭션으로 원자적 생성
             self.authRepository.createNewUserWithGroup(
                 user: userFirestore,
                 group: groupFirestore,
-                member: memberFirestore
+                member: memberFirestore,
+                invite: inviteFirestore
             )
             .subscribe(
                 onNext: { completeUser in

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/LoginUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/LoginUseCaseImpl.swift
@@ -112,45 +112,46 @@ final class LoginUseCase: LoginUseCaseProtocol {
             print("   - 그룹 ID: \(groupId)")
             print("   - 초대코드: \(inviteCode)")
             
-            let userFirestore = UserFirestore(
-                userId: authUser.uid,
+            // ✅ Domain 모델 생성
+            let user = User(
+                userID: authUser.uid,
                 nickname: randomNickname,
-                profileImage: authUser.photoURL,
-                groupId: groupId,
-                nicknameChangedAt: Timestamp(date: now),
-                createdAt: Timestamp(date: now)
+                profileImageURL: authUser.photoURL,
+                boards: [],
+                groupID: groupId,
+                groupName: "\(randomNickname)의 그룹",
+                isLeader: true,
+                joinedGroupAt: now
             )
             
-            let groupFirestore = GroupFirestore(
-                groupId: groupId,
-                name: "\(randomNickname)의 그룹",
-                leaderId: authUser.uid,
-                inviteCode: inviteCode,
-                nameChangedAt: Timestamp(date: now),
-                createdAt: Timestamp(date: now) 
+            let group = Group(
+                groupID: groupId,
+                members: [], // 멤버는 별도로 추가됨
+                leaderID: authUser.uid,
+                nameChangedAt: now
             )
             
-            let memberFirestore = MemberFirestore(
-                userId: authUser.uid,
+            let member = Member(
+                userID: authUser.uid,
                 nickname: randomNickname,
-                joinedAt: Timestamp(date: now),
+                joinedAt: now,
                 isLeader: true
             )
             
-            let inviteFirestore = InviteFirestore(
-                inviteCode: inviteCode,
-                groupId: groupId,
+            let invitation = Invitation(
+                groupID: groupId,
                 createdBy: authUser.uid,
-                createdAt: Timestamp(date: now),
-                expiredAt: nil // 영구 초대 코드
+                expiredAt: Date.distantFuture, // 영구 초대 코드
+                inviteCode: inviteCode,
+                createdAt: now
             )
             
             // 3. 트랜잭션으로 원자적 생성
             self.authRepository.createNewUserWithGroup(
-                user: userFirestore,
-                group: groupFirestore,
-                member: memberFirestore,
-                invite: inviteFirestore
+                user: user,
+                group: group,
+                member: member,
+                invite: invitation
             )
             .subscribe(
                 onNext: { completeUser in

--- a/StampIt-Project/StampIt-Project/Presentation/Common/UserCache.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/UserCache.swift
@@ -30,6 +30,7 @@ final class UserCache {
     func setCurrentUser(_ user: User) {
         cachedUser = user
         cacheTimestamp = Date()
+        // TODO: 리팩토링 단계에서 삭제 예정
         print("💾 사용자 정보 캐시 저장: \(user.nickname)")
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/Common/UserCache.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/UserCache.swift
@@ -1,0 +1,46 @@
+//
+//  UserCache.swift
+//  StampIt-Project
+//
+//  Created by iOS study on 6/16/25.
+//
+
+import Foundation
+
+final class UserCache {
+    static let shared = UserCache()
+    private init() {}
+    
+    // 메모리에만 캐시 저장
+    private var cachedUser: User?
+    private var cacheTimestamp: Date?
+    private let cacheValidDuration: TimeInterval = 300 // 5분
+    
+    func getCurrentUser() -> User? {
+        // 캐시 유효성 검사
+        if let cachedUser = cachedUser,
+           let timestamp = cacheTimestamp,
+           Date().timeIntervalSince(timestamp) < cacheValidDuration {
+            return cachedUser
+        }
+        
+        return nil
+    }
+    
+    func setCurrentUser(_ user: User) {
+        cachedUser = user
+        cacheTimestamp = Date()
+        print("💾 사용자 정보 캐시 저장: \(user.nickname)")
+    }
+    
+    func clearCache() {
+        cachedUser = nil
+        cacheTimestamp = nil
+    }
+    
+    // 캐시 상태 확인용
+    func isCacheValid() -> Bool {
+        guard let timestamp = cacheTimestamp else { return false }
+        return Date().timeIntervalSince(timestamp) < cacheValidDuration
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Common/WindowTransitionManager.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/WindowTransitionManager.swift
@@ -1,0 +1,42 @@
+//
+//  WindowTransitionManager.swift
+//  StampIt-Project
+//
+//  Created by iOS study on 6/16/25.
+//
+
+import UIKit
+
+// 공통 화면 전환 유틸리티
+final class WindowTransitionManager {
+    static let shared = WindowTransitionManager()
+    private init() {}
+    
+    /// 부드러운 루트 뷰컨트롤러 전환
+    func changeRootViewController(
+        to viewController: UIViewController,
+        duration: TimeInterval = 0.15,
+        completion: (() -> Void)? = nil
+    ) {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              let window = windowScene.windows.first else {
+            completion?()
+            return
+        }
+        
+        // 뷰 미리 로드
+        viewController.loadViewIfNeeded()
+        if let navController = viewController as? UINavigationController {
+            navController.viewControllers.forEach { $0.loadViewIfNeeded() }
+        }
+        
+        // 부드러운 전환
+        UIView.transition(with: window, duration: duration, options: .transitionCrossDissolve) {
+            window.rootViewController = viewController
+        } completion: { _ in
+            window.makeKeyAndVisible()
+            completion?()
+        }
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
@@ -15,7 +15,7 @@ final class LaunchViewController: UIViewController {
     
     // 1. 로딩 인디케이터 추가
     private let loadingIndicator = UIActivityIndicatorView(style: .large).then {
-        $0.color = .systemBlue
+        $0.color = UIColor(named: "red400")
         $0.hidesWhenStopped = true
     }
 

--- a/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
@@ -116,15 +116,6 @@ final class LaunchViewController: UIViewController {
     }
 
     private func changeRoot(_ vc: UIViewController) {
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-              let window = windowScene.windows.first else { return }
-        
-        // 6. 애니메이션 시간 단축 및 부드러운 전환
-        UIView.transition(with: window, duration: 0.15, options: .transitionCrossDissolve) {
-            window.rootViewController = vc
-        } completion: { _ in
-            window.makeKeyAndVisible()
-        }
+        WindowTransitionManager.shared.changeRootViewController(to: vc)
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
@@ -12,42 +12,118 @@ import RxSwift
 final class LaunchViewController: UIViewController {
     private let disposeBag = DisposeBag()
     private let loginUseCase = DIContainer.shared.loginUseCase
+    
+    // 1. 로딩 인디케이터 추가
+    private let loadingIndicator = UIActivityIndicatorView(style: .large).then {
+        $0.color = .systemBlue
+        $0.hidesWhenStopped = true
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         checkLaunchState()
     }
-
-    private func checkLaunchState() {
-        loginUseCase.checkLaunchState()
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] result in
-                guard let self = self else { return }
-                switch result.nextScreen {
-                case .main:
-                    self.showHome()
-                case .login, .onboarding:
-                    self.showLogin()
-                }
-            })
-            .disposed(by: disposeBag)
+    
+    // 2. UI 설정 추가
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        
+        [loadingIndicator].forEach {
+            view.addSubview($0)
+        }
+        
+        loadingIndicator.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        // 로딩 시작
+        loadingIndicator.startAnimating()
     }
 
+    private func checkLaunchState() {
+        // 3. 캐시된 사용자 정보가 있으면 바로 사용 (딜레이 제거)
+        if UserCache.shared.getCurrentUser() != nil {
+            showHome()
+            return
+        }
+        
+        // 4. 네트워크 조회 시 최소 딜레이 보장
+        loginUseCase.checkLaunchState()
+            .delay(.milliseconds(500), scheduler: MainScheduler.instance) // 최소 로딩 시간
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onNext: { [weak self] result in
+                    guard let self = self else { return }
+                    
+                    switch result.nextScreen {
+                    case .main:
+                        if let user = result.user {
+                            UserCache.shared.setCurrentUser(user)
+                        }
+                        self.showHome()
+                        
+                    case .login:
+                        self.showLogin()
+                        
+                    case .onboarding:
+                        self.showOnboarding()
+                    }
+                },
+                onError: { [weak self] error in
+                    self?.showLogin()
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+    
     private func showHome() {
+        // 5. 뷰컨트롤러 미리 생성 및 로드
         let homeVC = DIContainer.shared.makeHomeViewController()
-        changeRoot(UINavigationController(rootViewController: homeVC))
+        let navController = UINavigationController(rootViewController: homeVC)
+        
+        // 뷰 강제 로드 (검은 화면 방지)
+        navController.loadViewIfNeeded()
+        homeVC.loadViewIfNeeded()
+        
+        changeRoot(navController)
     }
 
     private func showLogin() {
         let loginVC = DIContainer.shared.makeLoginViewController()
-        changeRoot(UINavigationController(rootViewController: loginVC))
+        let navController = UINavigationController(rootViewController: loginVC)
+        
+        // 뷰 강제 로드
+        navController.loadViewIfNeeded()
+        loginVC.loadViewIfNeeded()
+        
+        changeRoot(navController)
+    }
+    
+    private func showOnboarding() {
+        let onboardingVC = DIContainer.shared.makeOnboardingViewController()
+        let navController = UINavigationController(rootViewController: onboardingVC)
+        
+        // 뷰 강제 로드
+        navController.loadViewIfNeeded()
+        onboardingVC.loadViewIfNeeded()
+        
+        changeRoot(navController)
     }
 
     private func changeRoot(_ vc: UIViewController) {
-        if let windowScene = UIApplication.shared.connectedScenes
+        guard let windowScene = UIApplication.shared.connectedScenes
             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-           let window = windowScene.windows.first {
+              let window = windowScene.windows.first else { return }
+        
+        // 6. 애니메이션 시간 단축 및 부드러운 전환
+        UIView.transition(with: window, duration: 0.15, options: .transitionCrossDissolve) {
             window.rootViewController = vc
+        } completion: { _ in
             window.makeKeyAndVisible()
         }
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Launch/ViewController/LaunchViewController.swift
@@ -1,0 +1,54 @@
+//
+//  LaunchViewController.swift
+//  StampIt-Project
+//
+//  Created by iOS study on 6/16/25.
+//
+
+import Foundation
+import UIKit
+import RxSwift
+
+final class LaunchViewController: UIViewController {
+    private let disposeBag = DisposeBag()
+    private let loginUseCase = DIContainer.shared.loginUseCase
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        checkLaunchState()
+    }
+
+    private func checkLaunchState() {
+        loginUseCase.checkLaunchState()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] result in
+                guard let self = self else { return }
+                switch result.nextScreen {
+                case .main:
+                    self.showHome()
+                case .login, .onboarding:
+                    self.showLogin()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func showHome() {
+        let homeVC = DIContainer.shared.makeHomeViewController()
+        changeRoot(UINavigationController(rootViewController: homeVC))
+    }
+
+    private func showLogin() {
+        let loginVC = DIContainer.shared.makeLoginViewController()
+        changeRoot(UINavigationController(rootViewController: loginVC))
+    }
+
+    private func changeRoot(_ vc: UIViewController) {
+        if let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+           let window = windowScene.windows.first {
+            window.rootViewController = vc
+            window.makeKeyAndVisible()
+        }
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
@@ -349,8 +349,19 @@ final class LoginViewController: UIViewController {
     
     /// 홈 화면으로 이동
     private func navigateToHome(user: User) {
-        // TODO: 홈 화면 ViewController로 이동 (홈화면 완전히 구성되면 작업 예정)
-        print("✅ 홈 화면으로 이동: \(user.nickname)")
+        // 1. DIContainer로 HomeViewController 생성
+        let homeVC = DIContainer.shared.makeHomeViewController()
+
+        // 2. windowScene(iOS 15+) 방식으로 rootViewController 교체
+        if let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+           let window = windowScene.windows.first {
+            window.rootViewController = UINavigationController(rootViewController: homeVC)
+            window.makeKeyAndVisible()
+        } else {
+            // 3. navigationController fallback
+            navigationController?.setViewControllers([homeVC], animated: true)
+        }
     }
     
     /// 신규 사용자 환영 메시지 표시

--- a/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
@@ -140,6 +140,21 @@ final class LoginViewController: UIViewController {
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     
+    /// 뷰컨트롤러 해제 전 정리
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        // 로딩 상태 정리
+        loadingIndicator.stopAnimating()
+        loadingContainerView.isHidden = true
+        
+        // 버튼 상태 복원
+        appleLoginButton.isEnabled = true
+        googleLoginButton.isEnabled = true
+        appleLoginButton.alpha = 1.0
+        googleLoginButton.alpha = 1.0
+    }
+    
     // MARK: - Setup UI
     private func setupUI() {
         view.backgroundColor = .systemBackground
@@ -332,20 +347,52 @@ final class LoginViewController: UIViewController {
         }
     }
     
-    /// 로그인 성공 처리
+    /// 로그인 성공 처리 (타임아웃 추가)
     private func handleLoginSuccess(user: User, isNewUser: Bool, nextAction: LoginNextAction) {
+        // 사용자 정보 캐시에 먼저 저장
+        UserCache.shared.setCurrentUser(user)
+        
         // 성공 햅틱 피드백
         let impactFeedback = UIImpactFeedbackGenerator(style: .light)
         impactFeedback.impactOccurred()
         
-        // 다음 화면으로 이동 처리
-        switch nextAction {
-        case .navigateToMain:
-            navigateToHome(user: user)
-        case .showWelcomeMessage:
-            showWelcomeMessage(user: user)
+        // 타임아웃 설정 (10초 후 강제 이동)
+        let timeoutWorkItem = DispatchWorkItem { [weak self] in
+            self?.forceNavigateToHome(user: user)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10, execute: timeoutWorkItem)
+        
+        // 정상 전환 시도
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            timeoutWorkItem.cancel() // 타임아웃 취소
+            
+            switch nextAction {
+            case .navigateToMain:
+                self?.navigateToHome(user: user)
+            case .showWelcomeMessage:
+                self?.showWelcomeMessage(user: user)
+            }
         }
     }
+
+    /// 강제 홈 화면 이동 (타임아웃 시)
+    private func forceNavigateToHome(user: User) {
+        
+        // 간단한 방식으로 이동
+        let homeVC = DIContainer.shared.makeHomeViewController()
+        let navController = UINavigationController(rootViewController: homeVC)
+        
+        // 즉시 전환 (애니메이션 없음)
+        if let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+           let window = windowScene.windows.first {
+            
+            window.rootViewController = navController
+            window.makeKeyAndVisible()
+        }
+    }
+
     
     /// 홈 화면으로 이동
     private func navigateToHome(user: User) {
@@ -357,8 +404,11 @@ final class LoginViewController: UIViewController {
     
     /// 신규 사용자 환영 메시지 표시
     private func showWelcomeMessage(user: User) {
-        // TODO: 신규 사용자 환영 토스트 메시지로 변경 예정
-        print("✅ 신규 사용자 환영: \(user.nickname)")
+        // TODO: 홈 화면 이동 후 신규 사용자 환영 토스트 메시지로 출력(미구현)
+        let homeVC = DIContainer.shared.makeHomeViewController()
+        let navController = UINavigationController(rootViewController: homeVC)
+        
+        WindowTransitionManager.shared.changeRootViewController(to: navController)
     }
     
     /// 에러 알림 표시

--- a/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
@@ -349,19 +349,10 @@ final class LoginViewController: UIViewController {
     
     /// 홈 화면으로 이동
     private func navigateToHome(user: User) {
-        // 1. DIContainer로 HomeViewController 생성
         let homeVC = DIContainer.shared.makeHomeViewController()
-
-        // 2. windowScene(iOS 15+) 방식으로 rootViewController 교체
-        if let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-           let window = windowScene.windows.first {
-            window.rootViewController = UINavigationController(rootViewController: homeVC)
-            window.makeKeyAndVisible()
-        } else {
-            // 3. navigationController fallback
-            navigationController?.setViewControllers([homeVC], animated: true)
-        }
+        let navController = UINavigationController(rootViewController: homeVC)
+        
+        WindowTransitionManager.shared.changeRootViewController(to: navController)
     }
     
     /// 신규 사용자 환영 메시지 표시


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
STAMPIT-95
  

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
InviteCode 활용할 수 있도록 AuthRepo, LoginUseCase, FirestoreManager 수정
1. AuthRepo, LoginUseCase에서 신규 사용자 생성 시 컬렉션 invites도 같이 작성되도록 수정
2. 1번의 변경사항에 맞게 Entities 수정
3. Repo, UseCase에서 활용할 수 있게 FirestoreManager도 CURD 수정(현재 그룹 코드 조회, 초대 코드로 그룹 정보 조회, 그룹변경(마이페이지 탈퇴 시 적용), 그룹 멤버 수 조회) 추가
---
의존성 역임 수정(AuthRepository, LoginVC)
1.  Repository에서 Domain 모델 사용
- createNewUserWithGroup 메서드가 Domain 모델을 받음
- Repository 내부에서 Infrastructure 모델로 변환
2. UseCase에서 Infrastructure 모델 생성 제거
- LoginUseCase에서 Domain 모델(User, Group, Member, Invitation) 생성
- Infrastructure 모델(UserFirestore 등) 생성 코드 제거
---
자동 로그인 구현
1. LaunchVC를 만들어 Login, Home 분기
2. 로그인의 경우 Home으로 이동
3. 로그아웃일 때, 회원 탈퇴일 때 LoginVC로 이동하는 흐름 추가 구현해야함
4. 화면 전환이 매끄럽지 않아서 애니메이션, 메모리 캐싱(더 빠른 네트워크 작업), loadingIndicator(color: red400), 화면 전환 유틸리티 추가하여 사용자 경험 높임

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/48b3ee17-37d0-4c50-adcb-d3b0f4a3fe37" width ="250">|

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
개선사항, 오타, 추가 CURD가 필요한 경우, 의존성 역임을 하는 경우 있다면 말씀부탁드립니다!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- CURD 작업하면서 자동로그인(메모리 캐싱, 애니메이션, 화면 전환에 사용할 수 있는 공통 유틸리티)까지 작업했습니다.
- 화면 전환 시 매끄러운 동작을 위해 뷰 미리 로드해두고, 딜레이 걸어서 부드럽게 화면 전환 될 수 있도록 공통 유틸리티 만들었습니다.  WindowTransitionManager.shared.changeRootViewController(to: )로 활용하시면 됩니다.