### PR TITLE
[Feat] STAMPIT-77 - 미션 화면 UI 개선

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -24,7 +24,7 @@ final class AssignMissionViewController: UIViewController {
     
     // 멤버 선택 버튼
     private lazy var memberSelectionButton = UIButton().then {
-        $0.configuration = configureButton(title: "멤버 선택하기")
+        $0.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray800)
         $0.addTarget(self, action: #selector(dropdown), for: .touchUpInside)
     }
     
@@ -146,7 +146,7 @@ final class AssignMissionViewController: UIViewController {
         }
         
         memberSelectionButton.snp.makeConstraints {
-            $0.width.equalTo(dueDatePicker.snp.width)
+            $0.width.equalTo(140)
         }
         
         dropdownView.snp.makeConstraints {
@@ -187,7 +187,7 @@ final class AssignMissionViewController: UIViewController {
             .drive { [weak self] member in
                 guard let self, let member else { return }
                 
-                memberSelectionButton.configuration = configureButton(title: member.nickname) // 버튼에 선택한 멤버 이름 표시
+                memberSelectionButton.configuration = configureButton(title: member.nickname, titleColor: .gray800) // 버튼에 선택한 멤버 이름 표시
                 assignButton.isEnabled = true // 미션 전달하기 버튼 활성화
                 dropdownView.isHidden = true
                 isDropdown = false
@@ -215,7 +215,7 @@ final class AssignMissionViewController: UIViewController {
     }
     
     // 멤버 선택 버튼 configuration 설정
-    private func configureButton(title: String) -> UIButton.Configuration {
+    private func configureButton(title: String, titleColor: UIColor) -> UIButton.Configuration {
         var configuration = UIButton.Configuration.filled()
         configuration.baseBackgroundColor = .gray25
         configuration.baseForegroundColor = .gray800
@@ -224,7 +224,7 @@ final class AssignMissionViewController: UIViewController {
         
         // 폰트 및 폰트 색상 설정
         let font = UIFont.pretendard(size: 16, weight: .regular)
-        let attributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: UIColor.gray800]
+        let attributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: titleColor]
         let attributedTitle = NSAttributedString(string: configuration.title ?? "", attributes: attributes)
         configuration.attributedTitle = AttributedString(attributedTitle)
         
@@ -251,7 +251,22 @@ final class AssignMissionViewController: UIViewController {
     // 멤버 선택 버튼을 누르면 드랍다운으로 멤버 리스트를 보여줌. 다시 누르면 닫음.
     @objc private func dropdown() {
         isDropdown.toggle()
-        dropdownView.isHidden = !isDropdown
+        
+        if isDropdown {
+            memberSelectionButton.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray200)
+            dropdownView.alpha = 0
+            dropdownView.isHidden = false
+            UIView.animate(withDuration: 0.25) { [weak self] in
+                self?.dropdownView.alpha = 1
+            }
+        } else {
+            memberSelectionButton.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray800)
+            UIView.animate(withDuration: 0.25) { [weak self] in
+                self?.dropdownView.alpha = 0
+            } completion: { [weak self] _ in
+                self?.dropdownView.isHidden = true
+            }
+        }
     }
     
     // 전달하기 버튼 누르면 원래 화면으로 복귀

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
@@ -13,7 +13,7 @@ final class MissionListCell: UITableViewCell {
     static let reuseIdentifier = "MissionListCell"
     
     private let label = UILabel().then {
-        $0.font = .pretendard(size: 14, weight: .regular)
+        $0.font = .pretendard(size: 16, weight: .regular)
         $0.numberOfLines = 0
     }
     


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-77

## 📌 변경 사항 및 이유
- 테이블 뷰의 미션 리스트 폰트 크기 조정: 14 -> 16(민경님 요청사항)
- 멤버 선택 화면 버튼 가로 길이 좀 더 크게
- 멤버 선택 누르면 "멤버 선택하기" 버튼 옅은 회색으로 변경되고, 화면 열릴 때 애니메이션 적용

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-17 at 09 15 35](https://github.com/user-attachments/assets/c0a597a6-47e7-404d-b948-382f827d2fc5)|

## 📌 PR Point
- 애니메이션이 자연스러운가? 제가 보기엔 아님 ㅠ

## 📌 참고 사항
아직 고칠게 많지만 미션 화면은 우선 여기서 마무리하고, 내 정보 수정 화면을 먼저 만들겠습니다.