### PR TITLE
[Fix] - deleteGroup 수정

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/FirestoreManager.swift
@@ -353,34 +353,45 @@ extension FirestoreManager {
             let groupRef = self.groupsCollection.document(groupId)
             let membersRef = groupRef.collection("members")
             let missionsRef = groupRef.collection("missions")
-            
+            let stickersQuery = self.stickersCollection.whereField("groupId", isEqualTo: groupId)
+
             // 1. 멤버 컬렉션 삭제
-            membersRef.getDocuments { snapshot, error in
+            membersRef.getDocuments { membersSnapshot, error in
                 if let error = error {
                     observer.onError(error)
                     return
                 }
                 let batch = Firestore.firestore().batch()
-                snapshot?.documents.forEach { doc in
+                membersSnapshot?.documents.forEach { doc in
                     batch.deleteDocument(doc.reference)
                 }
                 // 2. 미션 컬렉션 삭제
-                missionsRef.getDocuments { snapshot, error in
+                missionsRef.getDocuments { missionsSnapshot, error in
                     if let error = error {
                         observer.onError(error)
                         return
                     }
-                    snapshot?.documents.forEach { doc in
+                    missionsSnapshot?.documents.forEach { doc in
                         batch.deleteDocument(doc.reference)
                     }
-                    // 3. 그룹 문서 삭제
-                    batch.deleteDocument(groupRef)
-                    batch.commit { error in
+                    // 3. 스티커 컬렉션 삭제 (users/아닌 stickers/ 루트 기반)
+                    stickersQuery.getDocuments { stickersSnapshot, error in
                         if let error = error {
                             observer.onError(error)
-                        } else {
-                            observer.onNext(())
-                            observer.onCompleted()
+                            return
+                        }
+                        stickersSnapshot?.documents.forEach { doc in
+                            batch.deleteDocument(doc.reference)
+                        }
+                        // 4. 그룹 문서 삭제
+                        batch.deleteDocument(groupRef)
+                        batch.commit { error in
+                            if let error = error {
+                                observer.onError(error)
+                            } else {
+                                observer.onNext(())
+                                observer.onCompleted()
+                            }
                         }
                     }
                 }
@@ -388,7 +399,6 @@ extension FirestoreManager {
             return Disposables.create()
         }
     }
-    
     
     /// 그룹명 업데이트
     func updateGroupName(groupId: String, name: String, changedAt: Date) -> Observable<Void> {


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
누락된 스티커 컬렉션 같이 삭제될 수 있도록 수정했습니다
1. groupId 하위 members 컬렉션의 모든 멤버 문서 삭제
2. groupId 하위 missions 컬렉션의 모든 미션 문서 삭제
3. stickers 컬렉션에서 groupId가 일치하는 모든 스티커 문서 삭제
4. groupId 그룹 문서 자체 삭제
5. 모든 삭제 작업을 Firestore batch로 한 번에 커밋

## 📌 PR 포인트, 참고 사항
그룹이 삭제 되는 경우(1인 그룹인 경우, 그룹탈퇴)에 사용되는 코드로 다른 분들의 코드 작동에는 큰 지장 없을 것 같습니다.
