### PR TITLE
[Feat] STAMPIT-84 멤버 미션 더보기 화면 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/App/DIContainer.swift
+++ b/StampIt-Project/StampIt-Project/App/DIContainer.swift
@@ -54,6 +54,10 @@ final class DIContainer {
         return MyMissionUseCaseImpl(homeRepository: homeRepository)
     }()
 
+    lazy var memberMissionUseCase: MemberMissionUseCaseProtocol = {
+        return MemberMissionUseCaseImpl(homeRepository: homeRepository)
+    }()
+
     // MARK: - ViewModels (Domain Layer)
     func makeLoginViewModel() -> LoginViewModel {
         return LoginViewModel(loginUseCase: loginUseCase)
@@ -73,6 +77,10 @@ final class DIContainer {
 
     func makeMyMissionViewModel(user: User, memberCache: [String: User]) -> MyMissionViewModel {
         return MyMissionViewModel(user: user, memberCache: memberCache, useCase: myMissionUseCase)
+    }
+
+    func makeMemberMissionViewModel(user: User, memberCache: [String: User]) -> MemberMissionViewModel {
+        return MemberMissionViewModel(user: user, memberCache: memberCache, useCase: memberMissionUseCase)
     }
 
     // MARK: - ViewControllers (Presentation Layer)
@@ -99,6 +107,11 @@ final class DIContainer {
     func makeMyMissionViewController(user: User, memberCache: [String: User]) -> MyMissionViewController {
         let viewModel = makeMyMissionViewModel(user: user, memberCache: memberCache)
         return MyMissionViewController(viewModel: viewModel)
+    }
+
+    func makeMemberMissionViewController(user: User, memberCache: [String: User]) -> MemberMissionViewController {
+        let viewModel = makeMemberMissionViewModel(user: user, memberCache: memberCache)
+        return MemberMissionViewController(viewModel: viewModel)
     }
 
     // MARK: - Singleton

--- a/StampIt-Project/StampIt-Project/Domain/UseCase/MemberMissionUseCase.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCase/MemberMissionUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  MemberMissionUseCase.swift
+//  StampIt-Project
+//
+//  Created by daeun on 6/17/25.
+//
+
+import Foundation
+import RxSwift
+
+protocol MemberMissionUseCaseProtocol {
+    func fetchSendedMissions(ofUser userID: String, fromGroup groupID: String) -> Observable<[Mission]>
+}

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MemberMissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MemberMissionUseCaseImpl.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RxSwift
 
-final class MemberMissionUseCase: MemberMissionUseCaseProtocol {
+final class MemberMissionUseCaseImpl: MemberMissionUseCaseProtocol {
     let homeRepository: HomeRepositoryProtocol
 
     init(homeRepository: HomeRepositoryProtocol) {

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MemberMissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MemberMissionUseCaseImpl.swift
@@ -1,0 +1,24 @@
+//
+//  MemberMissionUseCase.swift
+//  StampIt-Project
+//
+//  Created by daeun on 6/17/25.
+//
+
+import Foundation
+import RxSwift
+
+final class MemberMissionUseCase: MemberMissionUseCaseProtocol {
+    let homeRepository: HomeRepositoryProtocol
+
+    init(homeRepository: HomeRepositoryProtocol) {
+        self.homeRepository = homeRepository
+    }
+
+    func fetchSendedMissions(ofUser userID: String, fromGroup groupID: String) -> Observable<[Mission]> {
+        homeRepository.fetchMissions(to: nil, by: userID, ofGroup: groupID)
+            .map { missions in
+                missions.sorted { $0.createDate > $1.createDate }
+            }
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/Model/MemberMissionItem.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/Model/MemberMissionItem.swift
@@ -1,0 +1,24 @@
+//
+//  MemberMissionItem.swift
+//  StampIt-Project
+//
+//  Created by daeun on 6/17/25.
+//
+
+import Foundation
+
+enum MemberMissionSection: Hashable, CaseIterable {
+    case mission
+}
+
+enum MemberMissionItem: Hashable {
+    case mission(HomeSendedMission)
+
+    var mission: HomeSendedMission? {
+        if case .mission(let mission) = self {
+            return mission
+        } else {
+            return nil
+        }
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/View/MemberMissionView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/View/MemberMissionView.swift
@@ -13,10 +13,6 @@ import RxRelay
 
 final class MemberMissionView: UIView {
 
-    // MARK: - Actions
-
-    let didTapStatusButton = PublishRelay<String>()
-
     // MARK: - Properties
 
     private let disposeBag = DisposeBag()

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/View/MemberMissionView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/View/MemberMissionView.swift
@@ -1,0 +1,137 @@
+//
+//  MemberMissionView.swift
+//  StampIt-Project
+//
+//  Created by daeun on 6/17/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxRelay
+
+final class MemberMissionView: UIView {
+
+    // MARK: - Actions
+
+    let didTapStatusButton = PublishRelay<String>()
+
+    // MARK: - Properties
+
+    private let disposeBag = DisposeBag()
+    private var dataSource: UICollectionViewDiffableDataSource<MemberMissionSection, MemberMissionItem>?
+
+    // MARK: - UI Components
+
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createLayout()
+    ).then {
+        $0.register(
+            AssignedMissionCell.self,
+            forCellWithReuseIdentifier: AssignedMissionCell.identifier
+        )
+    }
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .white
+        setHierarchy()
+        setConstraints()
+        setDataSource()
+        bind()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Set Hierarchy
+
+    private func setHierarchy() {
+        [
+            collectionView,
+        ].forEach { addSubview($0) }
+    }
+
+    // MARK: - Set Constraints
+
+    private func setConstraints() {
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide)
+            make.directionalHorizontalEdges.bottom.equalToSuperview()
+        }
+    }
+
+    // MARK: - Set DataSource
+
+    private func setDataSource() {
+        dataSource = .init(collectionView: collectionView) { collectionView, indexPath, item in
+            switch item {
+            case .mission(let mission):
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: AssignedMissionCell.identifier,
+                    for: indexPath
+                ) as! AssignedMissionCell
+
+                cell.configureAsSended(with: mission)
+
+                return cell
+            }
+        }
+
+        var snapshot = NSDiffableDataSourceSnapshot<MemberMissionSection, MemberMissionItem>()
+        snapshot.appendSections(MemberMissionSection.allCases)
+        dataSource?.apply(snapshot)
+    }
+
+    // MARK: - Bind
+
+    private func bind() {
+    }
+
+    // MARK: - Methods
+
+    func updateSnapshot(withItems items: [MemberMissionItem], toSection section: MemberMissionSection) {
+        guard var snapshot = dataSource?.snapshot() else { return }
+        let itemsToDelete = snapshot.itemIdentifiers(inSection: section)
+        snapshot.deleteItems(itemsToDelete)
+        snapshot.appendItems(items)
+        dataSource?.apply(snapshot, animatingDifferences: false)
+    }
+
+    private func createLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { [weak self] section, environment in
+            guard let self else { return nil }
+
+            let section = MyMissionSection.allCases[section]
+
+            switch section {
+            case .mission:
+                return createMissionSection()
+            }
+        }
+    }
+
+    private func createMissionSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .fractionalHeight(1)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(74)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 6
+        section.contentInsets = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
+        return section
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/ViewController/MemberMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/ViewController/MemberMissionViewController.swift
@@ -1,0 +1,56 @@
+//
+//  MemberMissionViewController.swift
+//  StampIt-Project
+//
+//  Created by daeun on 6/17/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class MemberMissionViewController: UIViewController {
+
+    // MARK: - Properties
+
+    private let viewModel: MemberMissionViewModel
+    private let disposeBag = DisposeBag()
+
+    // MARK: - UI Components
+
+    private let memberMissionView = MemberMissionView()
+
+    // MARK: - Life Cycles
+
+    init(viewModel: MemberMissionViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = memberMissionView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bind()
+    }
+
+    // MARK: - Bind
+
+    private func bind() {
+        viewModel.action.accept(.viewDidLoad)
+
+        viewModel.state.missions
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, items in
+                owner.memberMissionView.updateSnapshot(withItems: items, toSection: .mission)
+            }
+            .disposed(by: disposeBag)
+    }
+
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/ViewModel/MemberMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/ViewModel/MemberMissionViewModel.swift
@@ -1,0 +1,130 @@
+//
+//  MemberMissionViewModel.swift
+//  StampIt-Project
+//
+//  Created by daeun on 6/17/25.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+
+final class MemberMissionViewModel: ViewModelProtocol {
+    // MARK: - Dependency
+
+    private let useCase: MemberMissionUseCaseProtocol
+
+    // MARK: - Action & State
+
+    enum Action {
+        case viewDidLoad
+    }
+
+    struct State {
+        let user = BehaviorRelay<User?>(value: nil)
+        let missions = BehaviorRelay<[MemberMissionItem]>(value: [])
+    }
+
+    // MARK: - Properties
+
+    let disposeBag = DisposeBag()
+    let action = PublishRelay<Action>()
+    var state = State()
+    private var memberCache: [String: User] = [:]
+
+    // MARK: - Init
+
+    init(user: User, memberCache: [String: User], useCase: MemberMissionUseCaseProtocol) {
+        self.useCase = useCase
+        state.user.accept(user)
+        self.memberCache = memberCache
+        bind()
+    }
+
+    // MARK: - Bind
+
+    private func bind() {
+        action
+            .subscribe(with: self) { owner, action in
+                switch action {
+                case .viewDidLoad:
+                    owner.fetchMissions()
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+
+    /// 유저가 그룹 구성원에게 할당한 미션 바인딩
+    private func fetchMissions() {
+        guard let user = state.user.value else { return }
+        useCase.fetchSendedMissions(ofUser: user.userID, fromGroup: user.groupID)
+            .map { [weak self] in
+                guard let self else { return [] }
+                return mapMissionsToMemberMissionItems($0)
+            }
+            .bind(to: state.missions)
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Methods
+
+    private func mapMissionsToMemberMissionItems(_ missions: [Mission]) -> [MemberMissionItem] {
+        missions.map { mission in
+            let assigner = memberCache[mission.assignedBy]?.nickname ?? mission.assignedBy
+            let (isOverdue, daysLeft) = formatOverdueAndDays(from: mission.dueDate)
+            let missionItem = HomeSendedMission(
+                missionID: mission.missionID,
+                title: mission.title,
+                category: mission.category,
+                dueDate: mission.dueDate.toMonthDayString(),
+                assignee: assigner,
+                status: mission.status,
+                isOverdue: isOverdue,
+                daysLeft: daysLeft
+            )
+            return MemberMissionItem.mission(missionItem)
+        }
+    }
+
+    /// UI에서 미션 업데이트
+    private func updateMissionItem(missionID: String) {
+        let items = state.missions.value
+        let updated = items.map { item in
+            let mission = item.mission!
+            if mission.missionID == missionID {
+                let updated = HomeSendedMission(
+                    missionID: mission.missionID,
+                    title: mission.title,
+                    category: mission.category,
+                    dueDate: mission.dueDate,
+                    assignee: mission.assignee,
+                    status: .completed,
+                    isOverdue: mission.isOverdue,
+                    daysLeft: mission.daysLeft
+                )
+                return MemberMissionItem.mission(updated)
+            }
+            return item
+        }
+        state.missions.accept(updated)
+    }
+
+    private func isNew(createDate: Date) -> Bool {
+        let today = Calendar.current.dateComponents([.day], from: Date())
+        let created = Calendar.current.dateComponents([.day], from: createDate)
+        return today.day == created.day
+    }
+
+    private func formatOverdueAndDays(from dueDate: Date) -> (isOverdue: Bool, daysLeft: String) {
+        let cal = Calendar.current
+        let todayStart = cal.startOfDay(for: Date())
+        let dueStart = cal.startOfDay(for: dueDate)
+
+        let dayDiff = cal.dateComponents([.day], from: todayStart, to: dueStart).day ?? 0
+
+        let isOverdue = dayDiff < 0
+        let daysLeft = dayDiff == 0 ? "오늘" : "\(dayDiff)일 전"
+
+        return (isOverdue, daysLeft)
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/ViewModel/MyMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/ViewModel/MyMissionViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxRelay
 
-final class MyMissionViewModel {
+final class MyMissionViewModel: ViewModelProtocol {
     // MARK: - Dependency
 
     private let useCase: MyMissionUseCaseProtocol

--- a/StampIt-Project/StampIt-Project/Presentation/Home/View/HomeView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/View/HomeView.swift
@@ -16,6 +16,7 @@ final class HomeView: UIView {
     let didTapGroupOrganizationButton = PublishRelay<Void>()
     let didTapMissionCompleteButton = PublishRelay<String>()
     let didTapMoreReceivedMissionButton = PublishRelay<Void>()
+    let didTapMoreSendedMissionButton = PublishRelay<Void>()
     let username = PublishRelay<String>()
     let groupName = PublishRelay<String>()
 
@@ -83,6 +84,10 @@ final class HomeView: UIView {
 
         groupDashboardView.didTapMoreReceivedMissionButton
             .bind(to: didTapMoreReceivedMissionButton)
+            .disposed(by: disposeBag)
+
+        groupDashboardView.didTapMoreSendedMissionButton
+            .bind(to: didTapMoreSendedMissionButton)
             .disposed(by: disposeBag)
 
         username

--- a/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/GroupDashBoardView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/GroupDashBoardView.swift
@@ -19,6 +19,7 @@ final class GroupDashboardView: UIView {
 
     let didTapMissionCompleteButton = PublishRelay<String>()
     let didTapMoreReceivedMissionButton = PublishRelay<Void>()
+    let didTapMoreSendedMissionButton = PublishRelay<Void>()
     let username = BehaviorRelay<String>(value: "유저")
     let groupName = BehaviorRelay<String>(value: "그룹")
 
@@ -157,11 +158,16 @@ final class GroupDashboardView: UIView {
 
             case .sendedMission:
                 header.configure(title: "멤버 미션")
+
                 Observable
                     .combineLatest(username, groupName) { user, group in
                         "\(user)님이 \(group) 멤버들에게 전달한 미션이에요"
                     }
                     .bind(to: header.descriptionRxText)
+                    .disposed(by: header.disposeBag)
+
+                header.didTapMoreMissionButton
+                    .bind(to: didTapMoreSendedMissionButton)
                     .disposed(by: header.disposeBag)
             }
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
@@ -85,6 +85,11 @@ final class HomeViewController: UIViewController {
             .bind(to: viewModel.action)
             .disposed(by: disposeBag)
 
+        homeView.didTapMoreSendedMissionButton
+            .map { HomeViewModel.Action.didTapMoreSendedMissions }
+            .bind(to: viewModel.action)
+            .disposed(by: disposeBag)
+
         viewModel.state.user
             .asDriver()
             .drive(with: self) { owner, user in
@@ -119,6 +124,11 @@ final class HomeViewController: UIViewController {
                 owner.homeView.updateSnapshot(withItems: items, toSection: .sendedMission)
             }
             .disposed(by: disposeBag)
+
+        viewModel.state.isPushMemberMissionVC
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: pushMemberMissionVC)
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Methods
@@ -147,5 +157,14 @@ final class HomeViewController: UIViewController {
             memberCache: viewModel.memberCache
         )
         navigationController?.pushViewController(myMissionVC, animated: true)
+    }
+
+    private func pushMemberMissionVC() {
+        guard let user = viewModel.state.user.value else { return }
+        let memberMissionVC = DIContainer.shared.makeMemberMissionViewController(
+            user: user,
+            memberCache: viewModel.memberCache
+        )
+        navigationController?.pushViewController(memberMissionVC, animated: true)
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -24,7 +24,7 @@ final class HomeViewModel: ViewModelProtocol {
         case didTapCompleteCancelButton
         case didTapMoreReceivedMissions
         case didSelectReceivedMember(memberID: String)
-        case didTapMoreSenededMissions
+        case didTapMoreSendedMissions
     }
 
     struct State {
@@ -38,7 +38,7 @@ final class HomeViewModel: ViewModelProtocol {
         let isPushReceiveInvitationVC = PublishRelay<Void>()
         let isShowStickerReceived = PublishRelay<Void>()
         let isPushMyMissionVC = PublishRelay<Void>()
-        let isPushSendedMissionVC = PublishRelay<Void>()
+        let isPushMemberMissionVC = PublishRelay<Void>()
     }
 
     // MARK: - Properties
@@ -79,8 +79,8 @@ final class HomeViewModel: ViewModelProtocol {
                     owner.state.isPushMyMissionVC.accept(())
                 case .didSelectReceivedMember(memberID: let id):
                     owner.updateSendedMissions(memberID: id)
-                case .didTapMoreSenededMissions:
-                    owner.state.isPushSendedMissionVC.accept(())
+                case .didTapMoreSendedMissions:
+                    owner.state.isPushMemberMissionVC.accept(())
                 }
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-84
  
## 📌 변경 사항 및 이유
- 홈 화면에서 ‘멤버 미션’ 화면으로 이동 기능 구현
- 유저가 그룹 구성원에게 할당한 미션 더보기 화면 구현

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/e5fdc324-1429-4535-9cda-e9575c76f18c" width ="250">|


## 📌 PR Point
- 이 화면은 전체보기로 확인용이고, 현재로써는 별다른 기능이 없어서 기능면에서는 크게 리뷰하실 부분은 없을 겁니다.
- 지금 Home의 경우에는 HomeUseCase로 통합된 UseCase를 사용하고 있는데, 내 미션, 멤버 미션에서 각각 Home에서 사용하는 기능을 그대로 사용하고 있기 때문에, HomeUseCase를 없애고 [SendedMissionUseCase, ReceivedMissionUseCase, RankingUseCase] 이런식으로 나누어서 필요한 유즈케이스를 주입하도록 변경할 필요가 있을 것 같은데, 팀원분들 의견이 궁금합니다. (나눈다면 Home에서는 3개의 유즈케이스를 주입해줘야겠지만요..)
- 홈에서는 SendedMission-ReceivedMission를 사용하다가 각각의 화면에서는 MemberMission-MyMission이라는 네이밍을 사용하는데, 통일하는게 좋을 것 같네요. 어느쪽으로 통일할지도 의견 주시면 감사하겠습니다.

## 📌 참고 사항
- 필터링 안넣으니까 뚝딱이네요
- 미션이 많이 쌓이게 될 경우를 위해 추후 페이징 기능을 추가해야할 것 같습니다.
