### PR TITLE
[Feat] STAMPIT-110 커스텀 내비게이션 바, 토스트 적용(미션 뷰, 내 정보 수정 뷰)

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 import Then
 
 final class AssignMissionViewController: UIViewController {
+    private let navigationBar = DefaultNavigationBar(.titleWithBackButton(title: "미션 전달하기"))
+    
     private let missionTitleLabel = UILabel().then {
         $0.font = .pretendard(size: 18, weight: .bold)
     }
@@ -111,7 +113,7 @@ final class AssignMissionViewController: UIViewController {
         view.backgroundColor = .white
         
         // dropdownView는 보여질 때 일부 화면이 가려지므로(예: dueDateStackView) 마지막에 서브 뷰로 추가
-        [missionTitleLabel, memberStackView, dueDateStackView, assignButton, dropdownView].forEach {
+        [navigationBar, missionTitleLabel, memberStackView, dueDateStackView, assignButton, dropdownView].forEach {
             view.addSubview($0)
         }
         
@@ -125,13 +127,18 @@ final class AssignMissionViewController: UIViewController {
     }
     
     private func setConstraints() {
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.directionalHorizontalEdges.equalToSuperview()
+        }
+        
         missionTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(16)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
         memberStackView.snp.makeConstraints {
-            $0.top.equalTo(missionTitleLabel.snp.bottom).offset(32)
+            $0.top.equalTo(missionTitleLabel.snp.bottom).offset(24)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
@@ -155,10 +162,8 @@ final class AssignMissionViewController: UIViewController {
         }
     }
     
-    private func setNavigationBar() {
-        navigationItem.title = "미션 전달하기"
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.navigationBar.tintColor = .black
+    private func setNavigationBar() {        
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     private func bind() {
@@ -210,6 +215,13 @@ final class AssignMissionViewController: UIViewController {
                 guard let self else { return }
                 viewModel.action.accept(.didTapAssignButton)
                 dismiss()
+            }
+            .disposed(by: disposeBag)
+        
+        // 내비게이션 백버튼 누를 때
+        navigationBar.backTapped
+            .bind(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -26,6 +26,7 @@ final class AssignMissionViewController: UIViewController {
     
     // 멤버 선택 버튼
     private lazy var memberSelectionButton = UIButton().then {
+        $0.titleLabel?.numberOfLines = 1
         $0.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray800)
         $0.addTarget(self, action: #selector(dropdown), for: .touchUpInside)
     }
@@ -233,6 +234,7 @@ final class AssignMissionViewController: UIViewController {
         configuration.baseForegroundColor = .gray800
         configuration.cornerStyle = .medium
         configuration.title = title
+        configuration.titleLineBreakMode = .byTruncatingTail
         
         // 폰트 및 폰트 색상 설정
         let font = UIFont.pretendard(size: 16, weight: .regular)

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -35,6 +35,8 @@ final class MissionListViewController: UIViewController {
     
     private let headerView = HeaderView()
     
+    private let toastView = ToastView()
+    
     private let viewModel: MissionListViewModel
     private let disposeBag = DisposeBag()
     
@@ -66,12 +68,6 @@ final class MissionListViewController: UIViewController {
         
         // 미션 샘플 데이터 로드
         viewModel.action.accept(.onAppear)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        setNavigationBar() // 미션 할당 화면으로 이동 후 복귀 시 내비게이션 라지 타이틀 유지를 위해 필요
     }
     
     private func prepareSubviews() {
@@ -194,6 +190,10 @@ final class MissionListViewController: UIViewController {
     // 미션 할당 화면으로 이동
     private func pushAssignMissionViewController(mission: SampleMission) {
         let viewModel = AssignMissionViewModel(mission: mission, missionUseCaseImpl: DIContainer.shared.missionUseCase)
+        viewModel.onSuccess = { [weak self] in
+            guard let self else { return }
+            toastView.show(in: view, duration: 3, message: "미션이 전달되었어요")
+        }
         let viewController = AssignMissionViewController(viewModel: viewModel)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 import Then
 
 final class MissionListViewController: UIViewController {
+    private let navigationBar = DefaultNavigationBar(.plainTitle(title: "미션"))
+    
     private let searchBar = UISearchBar().then {
         $0.searchBarStyle = .minimal
         $0.placeholder = "검색어를 입력해주세요"
@@ -75,14 +77,19 @@ final class MissionListViewController: UIViewController {
     private func prepareSubviews() {
         view.backgroundColor = .white
         
-        [searchBar, collectionView, tableView].forEach {
+        [navigationBar, searchBar, collectionView, tableView].forEach {
             view.addSubview($0)
         }
     }
     
     private func setConstraints() {
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.directionalHorizontalEdges.equalToSuperview()
+        }
+        
         searchBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.top.equalTo(navigationBar.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
         }
         
@@ -100,14 +107,7 @@ final class MissionListViewController: UIViewController {
     }
     
     private func setNavigationBar() {
-        navigationItem.title = "미션"
-        navigationController?.navigationBar.prefersLargeTitles = true
-        
-        // 뒤로 가기 버튼 이미지를 화살표로 바꾸고 타이틀 삭제
-        let backButtonImage = UIImage(systemName: "arrow.left")
-        navigationController?.navigationBar.backIndicatorImage = backButtonImage
-        navigationController?.navigationBar.backIndicatorTransitionMaskImage = backButtonImage
-        navigationItem.backButtonTitle = ""
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     private func bind() {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
@@ -23,6 +23,8 @@ final class MissionListCell: UITableViewCell {
         contentView.addSubview(label)
         
         setConstraints()
+        
+        selectionStyle = .none
     }
     
     required init?(coder: NSCoder) {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -29,6 +29,8 @@ final class AssignMissionViewModel: ViewModelProtocol {
     
     var disposeBag = DisposeBag()
     
+    var onSuccess: (() -> Void)? // 새로운 미션이 생성되어 파이어베이스까지 저장 완료되었을 때 호출
+    
     private let mission: SampleMission
     private let missionUseCaseImpl: MissionUseCase
     private var user: User?
@@ -66,8 +68,9 @@ final class AssignMissionViewModel: ViewModelProtocol {
                 case .didTapAssignButton:
                     print("did tap assign button")
                     createMission()
-                        .subscribe {
+                        .subscribe { [weak self] in
                             print("mission created.")
+                            self?.onSuccess?()
                         } onError: { error in
                             print(error)
                         }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 import Then
 
 final class EditProfileViewController: UIViewController {
+    private let navigationBar = DefaultNavigationBar(.titleWithBackButton(title: "내 정보 수정"))
+    
     private let profileImageLabel = UILabel().then {
         $0.text = "프로필 이미지"
         $0.font = .pretendard(size: 14, weight: .regular)
@@ -140,7 +142,8 @@ final class EditProfileViewController: UIViewController {
             groupNameStackView.addArrangedSubview($0)
         }
         
-        [profileImageLabel,
+        [navigationBar,
+         profileImageLabel,
          collectionView,
          nicknameStackView,
          groupNameStackView,
@@ -150,8 +153,14 @@ final class EditProfileViewController: UIViewController {
     }
     
     private func makeConstraints() {
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.directionalHorizontalEdges.equalToSuperview()
+        }
+        
         profileImageLabel.snp.makeConstraints {
-            $0.top.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(16)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
         }
         
         collectionView.snp.makeConstraints {
@@ -161,7 +170,7 @@ final class EditProfileViewController: UIViewController {
         }
         
         nicknameStackView.snp.makeConstraints {
-            $0.top.equalTo(collectionView.snp.bottom).offset(16)
+            $0.top.equalTo(collectionView.snp.bottom).offset(24)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
@@ -191,16 +200,8 @@ final class EditProfileViewController: UIViewController {
         }
     }
     
-    private func setNavigationBar() {
-        navigationItem.title = "내 정보 수정"
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.navigationBar.tintColor = .black
-        
-        // !!!: 나를 호출하는 뷰 컨트롤러에 추가
-        let backButtonImage = UIImage(systemName: "arrow.left")
-        navigationController?.navigationBar.backIndicatorImage = backButtonImage
-        navigationController?.navigationBar.backIndicatorTransitionMaskImage = backButtonImage
-        navigationItem.backButtonTitle = ""
+    private func setNavigationBar() {        
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     private func setButtonAction() {
@@ -272,6 +273,13 @@ final class EditProfileViewController: UIViewController {
                 } else {
                     editButton.isEnabled = false
                 }
+            }
+            .disposed(by: disposeBag)
+        
+        // 내비게이션 백버튼 누를 때
+        navigationBar.backTapped
+            .bind(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-110

## 📌 변경 사항 및 이유
- 커스텀 내비게이션 바 적용: 미션 뷰, 내 정보 수정 뷰
- 토스트 메시지 적용: 미션 뷰

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro 미션 전달하기 완료 |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-19 at 12 43 02](https://github.com/user-attachments/assets/80e710d1-6747-4f50-a102-9d5f36cdb50e)|
| iPhone 16 Pro 그냥 백버튼 눌러서 복귀(토스트 메시지 안뜸) |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-19 at 12 43 16](https://github.com/user-attachments/assets/76735f5d-398b-4511-87a6-f554d5cc8c2f)|

## 📌 PR Point
파이어베이스 메서드 결과를 구독하여, 실제 파이어베이스 반영 완료되면 토스트 메시지 뜨도록 구현했습니다(만약 네트웍 딜레이 생긴다면 토스트 메시지도 늦어질 수 있을 것 같습니다)

## 📌 참고 사항
커스텀 내비게이션과 토스트 메시지 둘다 너무 잘 만드셨습니다. 사용 방법도 간단하고 가이드도 잘 해주셔서 쉽게 적용했습니다. 고맙습니다.