### PR TITLE
[Feat] STAMPIT-109 토스트 메세지 실패 경우 추가

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Common/Component/CustomToastView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Component/CustomToastView.swift
@@ -18,7 +18,7 @@ final class ToastView: UIView {
 
     private let iconImageView = UIImageView().then {
         $0.image = UIImage(named: "CheckCircleColored")
-        $0.tintColor = UIColor(.red400)
+//        $0.tintColor = UIColor(.red400)
     }
 
     private let contentStackView = UIStackView().then {
@@ -94,8 +94,10 @@ final class ToastView: UIView {
     }
 
     // MARK: - Show Toast
-    func show(in view: UIView, duration: TimeInterval = 2.0, message: String) {
+    func show(in view: UIView, duration: TimeInterval = 2.0, message: String, type: ToastType) {
         //이미 띄어진 경우 방지
+        iconImageView.image = type.icon
+        iconImageView.tintColor = type.tintColor
         messageLabel.text = message
         if self.superview != nil { return }
         view.addSubview(self)
@@ -128,3 +130,27 @@ final class ToastView: UIView {
         }
     }
 }
+
+enum ToastType {
+    case success
+    case failure
+
+    var icon: UIImage? {
+        switch self {
+        case .success:
+            return UIImage(named: "CheckCircleColored")
+        case .failure:
+            return UIImage(named: "xGray400")
+        }
+    }
+
+    var tintColor: UIColor {
+        switch self {
+        case .success:
+            return UIColor(.red400)
+        case .failure:
+            return UIColor(._4_E_4_E_4_E)
+        }
+    }
+}
+

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/ViewController/MyMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/ViewController/MyMissionViewController.swift
@@ -72,7 +72,7 @@ final class MyMissionViewController: UIViewController {
             guard let self else { return }
             if show {
                 let message = "'\(missionTitle.truncatedTo10)' 미션을 완료했어요!"
-                toastView.show(in: myMissionView, duration: 3, message: message)
+                toastView.show(in: myMissionView, duration: 3, message: message, type: .success)
             } else {
                 toastView.dismiss(duration: 0)
             }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
@@ -148,7 +148,7 @@ final class HomeViewController: UIViewController {
             guard let self else { return }
             if show {
                 let message = "'\(missionTitle.truncatedTo10)' 미션을 완료했어요!"
-                toastView.show(in: homeView, duration: 3, message: message)
+                toastView.show(in: homeView, duration: 3, message: message, type: .success)
             } else {
                 toastView.dismiss(duration: 0)
             }

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/ReceiveInviteViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/ReceiveInviteViewController.swift
@@ -167,11 +167,11 @@ final class ReceiveInviteViewController: UIViewController {
 
         viewModel.state.showMessage
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] message in
+            .subscribe(onNext: { [weak self] (type, message) in
                 guard let self = self else { return }
                 let toastView = ToastView()
 
-                toastView.show(in: self.view, message: message)
+                toastView.show(in: self.view, message: message, type: type)
             })
             .disposed(by: disposeBag)
 

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/SendInviteViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/SendInviteViewController.swift
@@ -85,7 +85,7 @@ final class SendInviteViewController: UIViewController {
         bindViewModel()
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = true
@@ -151,11 +151,11 @@ final class SendInviteViewController: UIViewController {
 
         viewModel.state.showMessage
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] message in
+            .subscribe(onNext: { [weak self] (type, message) in
                 guard let self = self else { return }
 
                 let toastView = ToastView()
-                toastView.show(in: self.view, message: message)
+                toastView.show(in: self.view, message: message, type: type)
             })
             .disposed(by: disposeBag)
 

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewModel/ReceiveInviteViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewModel/ReceiveInviteViewModel.swift
@@ -23,7 +23,7 @@ final class ReceiveInviteViewModel: ViewModelProtocol {
     struct State {
         let inviteCode = BehaviorRelay<String>(value: "")
         let isEnterButtonEnabled = BehaviorRelay<Bool>(value: false)
-        let showMessage = PublishRelay<String>()
+        let showMessage = PublishRelay<(ToastType, String)>()
         let didCompleteInvite = PublishRelay<Void>()
     }
 
@@ -69,7 +69,7 @@ final class ReceiveInviteViewModel: ViewModelProtocol {
         useCase.acceptInvite(inviteCode: code)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] invite in
-                self?.state.showMessage.accept("초대 완료!")
+                self?.state.showMessage.accept((.success, "초대 완료!"))
                 // MAKR: - 초대 완료가 됐을때 VC에 발행
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                     self?.state.didCompleteInvite.accept(())
@@ -79,15 +79,13 @@ final class ReceiveInviteViewModel: ViewModelProtocol {
                 print("[DEBUG] error type:", type(of: error))
                 let message: String
 
-                
-
                 if let repoError = error as? RepositoryError {
                     message = repoError.localizedDescription
                 } else {
                     message = "코드를 재확인 해주세요."
                 }
 
-                self?.state.showMessage.accept(message)
+                self?.state.showMessage.accept((.failure, message))
             })
             .disposed(by: disposeBag)
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewModel/SendInviteViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewModel/SendInviteViewModel.swift
@@ -18,7 +18,7 @@ final class SendInviteViewModel: ViewModelProtocol {
 
     struct State {
         let inviteCode = BehaviorRelay<String>(value: "")
-        let showMessage = PublishRelay<String>()
+        let showMessage = PublishRelay<(ToastType, String)>()
         let copyToClipboard = PublishRelay<String>()
 
     }
@@ -57,7 +57,7 @@ final class SendInviteViewModel: ViewModelProtocol {
             .subscribe(onNext: { [weak self] code in
                 guard let self = self else { return }
                 self.state.copyToClipboard.accept(code)
-                self.state.showMessage.accept("초대 코드가 복사되었습니다")
+                self.state.showMessage.accept((.success, "초대 코드가 복사되었습니다"))
             }, onError: { [weak self] error in
                 let message: String
 
@@ -67,7 +67,7 @@ final class SendInviteViewModel: ViewModelProtocol {
                     message = "오류가 발생했습니다."
                 }
 
-                self?.state.showMessage.accept(message)
+                self?.state.showMessage.accept((.failure, message))
             })
             .disposed(by: disposeBag)
     }
@@ -86,7 +86,7 @@ final class SendInviteViewModel: ViewModelProtocol {
                     message = "초대 코드를 불러오지 못했습니다."
                 }
 
-                self?.state.showMessage.accept(message)
+                self?.state.showMessage.accept((.failure, message))
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
요청이 실패인 경우에도 V버튼으로 보이는 것과 상반되는 토스트뷰가 보여져서 수정 했습니다.

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/c321031d-ae01-402b-b629-88c9353b6806" width ="250">|


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
toastView.show(in: homeView, duration: 3, message: message, type: .success) 
타입으로 .success / .failure를 추가했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
기본 이미지의 tint컬러를 제외하고 case 여부로 이미지, 색을 추가했습니다.
homeVC mymissionVC에서 성공 하는 경우만 확인되어 .success로 타입을 추가 했습니다.