### PR TITLE
[Fix] 새 미션 만들 때 전달 정보 nickname -> userID로 변경

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -109,15 +109,16 @@ final class AssignMissionViewModel: ViewModelProtocol {
     
     // 미션 정보 저장
     private func createMission() -> Observable<Void> {
+        let member = state.selectedMember.value
         let dueDate = state.dueDate.value
-        guard let user else {
+        guard let member, let user else {
             return Observable.error(NSError(domain: "user data is nil.", code: 0, userInfo: nil))
         }
         
         let mission = Mission(
             missionID: mission.missionId,
             title: mission.title,
-            assignedTo: user.userID,
+            assignedTo: member.userID,
             assignedBy: user.userID,
             createDate: Date(),
             dueDate: dueDate,

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -109,17 +109,16 @@ final class AssignMissionViewModel: ViewModelProtocol {
     
     // 미션 정보 저장
     private func createMission() -> Observable<Void> {
-        let nickname = state.selectedMember.value.map { $0.nickname }
         let dueDate = state.dueDate.value
-        guard let nickname, let user else {
-            return Observable.error(NSError(domain: "user data or member data is nil.", code: 0, userInfo: nil))
+        guard let user else {
+            return Observable.error(NSError(domain: "user data is nil.", code: 0, userInfo: nil))
         }
         
         let mission = Mission(
             missionID: mission.missionId,
             title: mission.title,
-            assignedTo: nickname,
-            assignedBy: user.nickname,
+            assignedTo: user.userID,
+            assignedBy: user.userID,
             createDate: Date(),
             dueDate: dueDate,
             status: MissionStatus.assigned,


### PR DESCRIPTION
## 📌 관련 이슈
없음
 
## 📌 변경 사항 및 이유
새 미션 만들 때 전달 정보 nickname -> userID로 변경

## 📌 구현 내역 스크린샷
없음

## 📌 PR Point
없음

## 📌 참고 사항
없음