### PR TITLE
[Setting] STAMPIT-112 - 다국어 설정

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/AuthError.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/AuthError.swift
@@ -25,15 +25,15 @@ enum AuthError: Error, LocalizedError {
         case .presentingViewControllerNotFound:
             return "화면을 찾을 수 없습니다."
         case .googleSignInFailed:
-            return "Google 로그인 실패했습니다."
+            return ""
         case .tokenRetrievalFailed:
             return "토큰을 가져올 수 없습니다."
         case .firebaseSignInFailed:
             return "Firebase 로그인 실패에 실패했습니다."
         case .appleSignInCanceled:
-            return "Apple 로그인이 취소되었습니다"
+            return ""
         case .appleSignInNotImplemented:
-            return "Apple 로그인은 아직 구현되지 않았습니다."
+            return "" // TODO: 리팩토링때 삭제, 애플 로그인 구현 전 에러
         case .signOutFailed:
             return "로그아웃에 실패했습니다."
         case .accountDeletionFailed:

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
@@ -315,7 +315,7 @@ final class AuthRepository: AuthRepositoryProtocol {
         if let authError = error as? AuthError {
             switch authError {
             case .googleSignInFailed:
-                return .authenticationFailed("Google 로그인 실패")
+                return .authenticationFailed("") // TODO: 부용아 나중에 삭제하도록 하렴(리팩토링)
             case .firebaseSignInFailed:
                 return .authenticationFailed("Firebase 로그인 실패")
             case .userNotFound:

--- a/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Login/ViewController/LoginViewController.swift
@@ -74,18 +74,18 @@ final class LoginViewController: UIViewController {
         button.layer.borderColor = UIColor(red: 218/255, green: 220/255, blue: 224/255, alpha: 1).cgColor // 공식 가이드 연회색
         button.clipsToBounds = true
 
-        let title = "Sign in with Google"
-        let font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        let title = NSLocalizedString("login_google", comment: "")
+        let font = UIFont.systemFont(ofSize: 18, weight: .medium)
 
         let googleLogo = UIImage(named: "GoogleLogo")
         let imageAttachment = NSTextAttachment()
         imageAttachment.image = googleLogo
-        imageAttachment.bounds = CGRect(x: 0, y: -2, width: 20, height: 20)
+        imageAttachment.bounds = CGRect(x: 0, y: -2, width: 18, height: 18)
 
         let fullString = NSMutableAttributedString()
         fullString.append(NSAttributedString(attachment: imageAttachment))
-        // 10pt 간격
-        let space = NSAttributedString(string: "\u{200A}", attributes: [.font: font, .kern: 10])
+        // 5pt 간격
+        let space = NSAttributedString(string: "\u{200A}", attributes: [.font: font, .kern: 5])
         fullString.append(space)
         fullString.append(NSAttributedString(string: title, attributes: [
             .font: font,
@@ -94,7 +94,7 @@ final class LoginViewController: UIViewController {
         button.setAttributedTitle(fullString, for: .normal)
 
         button.setImage(nil, for: .normal)
-        button.accessibilityLabel = "구글로 로그인하기"
+        button.accessibilityLabel = NSLocalizedString("login_google_kr", comment: "")
         return button
     }()
     
@@ -232,12 +232,12 @@ final class LoginViewController: UIViewController {
         
         // Apple 로그인 버튼 높이
         appleLoginButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
         }
         
         // Google 로그인 버튼 높이
         googleLoginButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
         }
         
         // 로딩 컨테이너 제약조건 (최하단)

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -98,7 +98,7 @@ final class MyPageViewController: UIViewController {
         
         viewModel.state.alertMessage
             .bind(with: self) { owner, message in
-                owner.showAlert(title: "알림", message: message)
+                owner.showAlert(title: "1인 그룹에서는 그룹 탈퇴가 지원되지 않아요.", message: message)
             }.disposed(by: disposeBag)
         
         // 로그인 화면으로 이동

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -205,7 +205,7 @@ final class MyPageViewModel: ViewModelProtocol {
 
         if memberCount <= 1 {
             // 본인만 있는 경우: 탈퇴 불가
-            state.alertMessage.accept("혼자 있는 그룹에서는 탈퇴할 수 없습니다.\n계정 탈퇴를 원하시면 '서비스 탈퇴'를 이용해주세요.")
+            state.alertMessage.accept("계정 삭제를 원하신다면\n'서비스 탈퇴'를 이용해주세요.")
         }else if currentUser.isLeader {
                 // 리더도 탈퇴 가능하되, 자동 위임 안내
                 state.shouldShowConfirmAlert.accept((

--- a/StampIt-Project/StampIt-Project/Resource/en.lproj/Localizable.strings
+++ b/StampIt-Project/StampIt-Project/Resource/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+  StampIt-Project
+
+  Created by iOS study on 6/20/25.
+  
+*/
+"login_google" = "Sign in with Google";
+"login_google_kr" = "Sign in with Google";

--- a/StampIt-Project/StampIt-Project/Resource/ko.lproj/Localizable.strings
+++ b/StampIt-Project/StampIt-Project/Resource/ko.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  StampIt-Project
+
+  Created by iOS study on 6/20/25.
+  
+*/
+
+"login_google" = "Google로 로그인";
+"login_google_kr" = "Google로 로그인";


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-112

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 기본 ko
2. 영어 en
- 현재 소셜 로그인만 분기해둠 ---
소셜 로그인 버튼 크기 수정(44 -> 48) 변경된 애플 소셜 로그인 사이즈에 맞게 구글 로그인도 수정(이미지 18p, 이미지-텍스트 간격 5p, 텍스트 크기 18p로 수정)

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/feec9b88-4c4e-457e-be45-88d7fb2c9248" width ="250">|

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
테스트 플라이는 이미 보내드렸고, 가장 최신 메일의 테스트 플라이 진행해주시면 됩니다.
추후 다국어 설정은 Localizable.strings으로 설정하시면 됩니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
내일 오전에 앱 배포 페이지 내용 작성 예정입니다.