### PR TITLE
[Fix] 미션 화면에서 키보드 내려가지 않는 현상 해결

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -24,6 +24,7 @@ final class MissionListViewController: UIViewController {
     
     private lazy var tableView = UITableView().then {
         $0.register(MissionListCell.self, forCellReuseIdentifier: MissionListCell.reuseIdentifier)
+        $0.keyboardDismissMode = .onDrag
         $0.delegate = self
     }
     
@@ -68,6 +69,8 @@ final class MissionListViewController: UIViewController {
         bind()
         
         setCollectionViewCell()
+        
+        setTapGesture()
         
         // 미션 샘플 데이터 로드
         viewModel.action.accept(.onAppear)
@@ -188,6 +191,17 @@ final class MissionListViewController: UIViewController {
         // 전체보기 셀의 isSelected = true로 설정
         let defaultSelection = IndexPath(item: 0, section: 0)
         collectionView.selectItem(at: defaultSelection, animated: false, scrollPosition: [])
+    }
+    
+    // 서치바 바깥 화면을 터치하면 키보드 내려감
+    private func setTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
     
     // 미션 할당 화면으로 이동


### PR DESCRIPTION
## 📌 관련 이슈
없음

## 📌 변경 사항 및 이유
미션 화면에서 키보드 내려가지 않는 현상 해결
- 키보드 밖을 눌러도 키보드 안내려감
- 카테고리 버튼을 눌러도 키보드 안내려감
- 미션 전달하기 화면을 갔다와도 키보드 안내려감
- 키보드 안내려가서 탭바로 다른 화면 이동 못함

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro(기존)어떻게 해도 키보드 안내려감|![Simulator Screen Recording - iPhone 16 Pro - 2025-06-20 at 10 19 15](https://github.com/user-attachments/assets/5e1f372f-d914-4e96-a8c5-d02f9e05a892)|
| iPhone 16 Pro(개선) |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-20 at 10 22 36](https://github.com/user-attachments/assets/a3f021cf-088c-4d6b-8bb2-1532c0943008)|

## 📌 PR Point
죄송합니다

## 📌 참고 사항
죄송합니다