### PR TITLE
[Feat] STAMPIT-121 - 미션 화면 리팩토링

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -30,6 +30,7 @@ final class MissionListViewController: UIViewController {
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout()).then {
         $0.register(CategoryCell.self, forCellWithReuseIdentifier: CategoryCell.reuseIdentifier)
+        $0.isScrollEnabled = false
     }
     
     private let noResultsView = NoResultsView().then {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -110,6 +110,8 @@ final class MissionListViewController: UIViewController {
     
     private func setNavigationBar() {
         navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
     
     private func bind() {
@@ -267,5 +269,12 @@ extension MissionListViewController: UITableViewDelegate {
             return 0
         }
         return 16
+    }
+}
+
+extension MissionListViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // navigationController의 viewControllers가 2개 이상일 때만 pop 허용
+        return navigationController?.viewControllers.count ?? 0 > 1
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -37,9 +37,18 @@ final class AssignMissionViewModel: ViewModelProtocol {
     
     init(
         mission: SampleMission,
+        selectedMember: Member? = nil,
         missionUseCaseImpl: MissionUseCase
     ) {
         self.mission = mission
+        
+        // 홈 화면에서 특정 멤버가 선택된 상태에서 미션 화면으로 진입할 때 사용
+        if let selectedMember {
+            var members: [Member] = []
+            members.append(selectedMember)
+            state.members.accept(members)
+        }
+        
         self.missionUseCaseImpl = missionUseCaseImpl
         
         bind()
@@ -87,7 +96,13 @@ final class AssignMissionViewModel: ViewModelProtocol {
                 guard let self else { return }
                 
                 self.user = user
-                fetchMembers() // 유저 정보를 받으면 멤버 정보 요청
+                
+                // 유저 정보를 받으면 멤버 정보 요청
+                // 홈 화면에서 특정 멤버가 선택된 상태에서 미션 화면으로 진입할 때는 멤버 정보 패치 불필요
+                if state.members.value.isEmpty {
+                    fetchMembers()
+                }
+                
             } onError: { error in
                 print(error)
             }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -132,7 +132,7 @@ final class AssignMissionViewModel: ViewModelProtocol {
         }
         
         let mission = Mission(
-            missionID: mission.missionId,
+            missionID: UUID().uuidString,
             title: mission.title,
             assignedTo: member.userID,
             assignedBy: user.userID,

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -22,6 +22,7 @@ final class EditProfileViewController: UIViewController {
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout()).then {
         $0.register(ProfileImageCell.self, forCellWithReuseIdentifier: ProfileImageCell.reuseIdentifier)
+        $0.isScrollEnabled = false
     }
     
     private let nicknameLabel = UILabel().then {


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-121

## 📌 변경 사항 및 이유
- 홈 화면에서 특정 멤버를 선택한 상태로 미션 화면에 진입할 수 있게 변경
- 내비게이션 바 백 스와이프 안되는 현상 해결
- 컬렉션 뷰가 위아래로 조금 스크롤되는 현상 해결
- 미션 ID 체계 변경(중요): "family_001" -> UUID

## 📌 구현 내역 스크린샷
생략

## 📌 PR Point
미션 ID 체계 변경되었습니다. 제가 1차 테스트 했지만(제 계정1에서 미션 만들어서 계정2 전달 -> 계정2에서 완료처리), 반드시 각자 맡으신 부분에서 문제없는지 확인 부탁드립니다.

## 📌 참고 사항
다은님은 아래 코드 참조하셔서 미션화면 이동 구현하시면 됩니다.

let viewModel = AssignMissionViewModel(mission: mission, selectedMember: 특정 멤버, missionUseCaseImpl: DIContainer.shared.missionUseCase)
viewModel.onSuccess = { [weak self] in
            guard let self else { return }
            toastView.show(in: view, duration: 3, message: "미션이 전달되었어요", type: .success)
}
let viewController = AssignMissionViewController(viewModel: viewModel)
navigationController?.pushViewController(viewController, animated: true)