### PR TITLE
[Fix] STAMPIT-114 미션 셀 동적 레이아웃 및 UI 개선, 랭킹 개인 표기 추가 & 버그 수정

### DIFF
--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/HomeUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/HomeUseCaseImpl.swift
@@ -80,7 +80,11 @@ final class HomeUseCase: HomeUseCaseProtocol {
     /// 만료된 assigned 미션을 서버에 failed로 업데이트하고
     /// 나머지 미션과 합쳐서 생성일 순으로 내림차순 정렬된 배열을 방출
     private func handleExpiredAndMerge(missions: [Mission], groupID: String) -> Observable<[Mission]> {
-        let toExpire = missions.filter { $0.status == .assigned && $0.dueDate < Date() }
+        let toExpire = missions.filter {
+            let dueDay = Calendar.current.component(.day, from: $0.dueDate)
+            let today = Calendar.current.component(.day, from: Date())
+            return $0.status == .assigned && dueDay < today
+        }
         let others = missions.filter { !toExpire.contains($0) }
 
         return Observable

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
@@ -30,12 +30,23 @@ final class AssignedMissionCell: UICollectionViewCell {
 
     // MARK: - UI Components
 
+    private let contentStackView = UIStackView().then {
+        $0.spacing = 12
+        $0.alignment = .center
+    }
+
     private let imageContainerView = UIView().then {
         $0.layer.cornerRadius = 8
     }
 
     private let categoryImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFit
+    }
+
+    private let tagAndTitleStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 4
+        $0.alignment = .leading
     }
 
     private let tagStackView = UIStackView().then {
@@ -51,8 +62,10 @@ final class AssignedMissionCell: UICollectionViewCell {
     private let dateTag = TagView(type: .filledBold)
 
     private let titleLabel = UILabel().then {
+        $0.setTextWithLineHeight(text: nil, lineHeight: 21)
         $0.font = .pretendard(size: 14, weight: .regular)
         $0.textColor = .gray800
+        $0.numberOfLines = 0
     }
 
     private let statusView = UIView()
@@ -110,23 +123,31 @@ final class AssignedMissionCell: UICollectionViewCell {
 
     private func setHierarchy() {
         [
-            imageContainerView,
-            tagStackView,
-            titleLabel,
+            contentStackView,
             statusView,
             statusButton,
             separatorView,
         ].forEach{ contentView.addSubview($0) }
 
         [
+            imageContainerView,
+            tagAndTitleStackView,
+        ].forEach { contentStackView.addArrangedSubview($0) }
+
+        [
             categoryImageView,
         ].forEach { imageContainerView.addSubview($0) }
+
+        [
+            tagStackView,
+            titleLabel,
+        ].forEach { tagAndTitleStackView.addArrangedSubview($0) }
 
         [
             newTag,
             nameTag,
             dateTag,
-            ].forEach { tagStackView.addArrangedSubview($0) }
+        ].forEach { tagStackView.addArrangedSubview($0) }
         
         [
             daysLeftLabel,
@@ -138,9 +159,13 @@ final class AssignedMissionCell: UICollectionViewCell {
     // MARK: - Set Constraints
 
     private func setConstraints() {
-        imageContainerView.snp.makeConstraints { make in
+        contentStackView.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview().inset(12)
             make.leading.equalToSuperview()
+            make.trailing.equalTo(statusButton.snp.leading).offset(-20)
+        }
+
+        imageContainerView.snp.makeConstraints { make in
             make.size.equalTo(50)
         }
 
@@ -149,23 +174,10 @@ final class AssignedMissionCell: UICollectionViewCell {
             make.size.equalTo(35)
         }
 
-        tagStackView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(13.5)
-            make.leading.equalTo(imageContainerView.snp.trailing).offset(12)
-        }
-
-        titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(tagStackView.snp.bottom).offset(4)
-            make.leading.equalTo(imageContainerView.snp.trailing).offset(12)
-            make.trailing.equalToSuperview().inset(80)
-            make.bottom.equalToSuperview().inset(13.5)
-            make.height.equalTo(21)
-        }
-
         statusView.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview().inset(15.5)
             make.trailing.equalToSuperview()
-            make.width.equalTo(80)
+            make.width.equalTo(46)
         }
 
         daysLeftLabel.snp.makeConstraints { make in

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
@@ -55,6 +55,7 @@ final class AssignedMissionCell: UICollectionViewCell {
 
     private let newTag = TagView(type: .outlined).then {
         $0.updateText(with: "New")
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     private let nameTag = TagView(type: .filledBold)
@@ -232,7 +233,7 @@ final class AssignedMissionCell: UICollectionViewCell {
         self.type = .sended
         imageContainerView.backgroundColor = mission.category.backgroundColor
         categoryImageView.image = mission.category.image
-        nameTag.updateText(with: mission.assignee)
+        nameTag.updateText(with: "to." + mission.assignee)
         dateTag.updateText(with: "~" + mission.dueDate)
         if mission.isOverdue { dateTag.updateTextColor(.gray200) }
         daysLeftLabel.text = mission.daysLeft
@@ -246,7 +247,7 @@ final class AssignedMissionCell: UICollectionViewCell {
         imageContainerView.backgroundColor = mission.category.backgroundColor
         categoryImageView.image = mission.category.image
         newTag.isHidden = !(mission.isNew ?? false)
-        nameTag.updateText(with: mission.assigner)
+        nameTag.updateText(with: "from." + mission.assigner)
         dateTag.updateText(with: "~" + mission.dueDate)
         if mission.isOverdue { dateTag.updateTextColor(.gray200) }
         titleLabel.text = mission.title

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
@@ -208,6 +208,16 @@ final class AssignedMissionCell: UICollectionViewCell {
         }
     }
 
+    private func updateContentStackViewConstraints() {
+        let trailingView = type == .received ? statusButton : statusView
+
+        contentStackView.snp.remakeConstraints { make in
+            make.verticalEdges.equalToSuperview().inset(12)
+            make.leading.equalToSuperview()
+            make.trailing.equalTo(trailingView.snp.leading).offset(-20)
+        }
+    }
+
     // MARK: - Bind
 
     private func bind() {
@@ -228,6 +238,7 @@ final class AssignedMissionCell: UICollectionViewCell {
         daysLeftLabel.text = mission.daysLeft
         titleLabel.text = mission.title
         updateStatusView(for: mission.status)
+        updateContentStackViewConstraints()
     }
 
     func configureAsReceived(with mission: HomeReceivedMission) {
@@ -240,6 +251,7 @@ final class AssignedMissionCell: UICollectionViewCell {
         if mission.isOverdue { dateTag.updateTextColor(.gray200) }
         titleLabel.text = mission.title
         statusButton.updateStatus(to: mission.status)
+        updateContentStackViewConstraints()
     }
 
     private func toggleViewOnType() {

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/CompletionStateButton.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/CompletionStateButton.swift
@@ -34,6 +34,14 @@ final class CompletionStateButton: UIControl {
 
     private let titleLabel = UILabel().then {
         $0.font = .pretendard(size: 14, weight: .semibold)
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let viewSize = containerStackView.intrinsicContentSize
+        let width = viewSize.width + 8 * 2
+        let height = viewSize.height + 4.5 * 2
+        return CGSize(width: width, height: height)
     }
 
     // MARK: - Init

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/MemberCompactCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/MemberCompactCell.swift
@@ -29,14 +29,11 @@ final class MemberCompactCell: UICollectionViewCell {
 
     // MARK: - UI Components
 
-    private let imageContainerView = UIView().then {
+    private let profileImageView = UIImageView().then {
+        $0.contentMode = .center
         $0.backgroundColor = .clear
         $0.layer.cornerRadius = 60 / 2
         $0.clipsToBounds = true
-    }
-
-    private let profileImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFit
     }
     
     private let rankBadgeImageView = UIImageView().then {
@@ -73,9 +70,9 @@ final class MemberCompactCell: UICollectionViewCell {
     private func setStyles() {
         rankBadgeImageView.isHidden = type != .rank
         stickerCountLabel.isHidden = type != .rank
-        imageContainerView.layer.borderWidth = borderWidth
-        imageContainerView.layer.borderColor = borderColor
-        imageContainerView.layer.opacity = opacity
+        profileImageView.layer.borderWidth = borderWidth
+        profileImageView.layer.borderColor = borderColor
+        profileImageView.layer.opacity = opacity
         nameLabel.textColor = nameTextColor
     }
 
@@ -83,40 +80,31 @@ final class MemberCompactCell: UICollectionViewCell {
 
     private func setHierarchy() {
         [
-            imageContainerView,
+            profileImageView,
             rankBadgeImageView,
             nameLabel,
             stickerCountLabel,
         ].forEach { addSubview($0) }
-
-        [
-            profileImageView
-        ].forEach { imageContainerView.addSubview($0) }
     }
 
     // MARK: - Set Constraints
 
     private func setConstraints() {
-        imageContainerView.snp.makeConstraints { make in
+        profileImageView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.centerX.equalToSuperview()
             make.size.equalTo(60)
         }
 
-        profileImageView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
-            make.size.equalTo(40)
-        }
-
         rankBadgeImageView.snp.makeConstraints { make in
-            make.bottom.equalTo(imageContainerView.snp.bottom).offset(4)
+            make.bottom.equalTo(profileImageView.snp.bottom).offset(4)
             make.centerX.equalToSuperview()
             make.size.equalTo(16)
         }
 
         nameLabel.snp.makeConstraints { make in
             let offset = type == .rank ? 8 : 4
-            make.top.equalTo(imageContainerView.snp.bottom).offset(offset)
+            make.top.equalTo(profileImageView.snp.bottom).offset(offset)
             make.directionalHorizontalEdges.equalToSuperview()
             make.height.equalTo(21)
         }
@@ -131,7 +119,7 @@ final class MemberCompactCell: UICollectionViewCell {
     private func updateNameLabelConstraints() {
         nameLabel.snp.updateConstraints { make in
             let offset = type == .rank ? 8 : 4
-            make.top.equalTo(imageContainerView.snp.bottom).offset(offset)
+            make.top.equalTo(profileImageView.snp.bottom).offset(offset)
         }
     }
 
@@ -155,9 +143,9 @@ final class MemberCompactCell: UICollectionViewCell {
 
     private func setStylesIfSelectedForNormalType() {
         guard type == .normal else { return }
-        imageContainerView.layer.borderColor = borderColor
-        imageContainerView.layer.borderWidth = borderWidth
-        imageContainerView.layer.opacity = opacity
+        profileImageView.layer.borderColor = borderColor
+        profileImageView.layer.borderWidth = borderWidth
+        profileImageView.layer.opacity = opacity
         nameLabel.textColor = nameTextColor
     }
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/TagView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/TagView.swift
@@ -38,6 +38,13 @@ final class TagView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override var intrinsicContentSize: CGSize {
+        let labelSize = label.intrinsicContentSize
+        let width = labelSize.width + 8 * 2
+        let height = labelSize.height + verticalInset * 2
+        return CGSize(width: width, height: height)
+    }
+
     // MARK: - Set Styles
 
     private func setStyles() {

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/View/MemberMissionView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MemberMission/View/MemberMissionView.swift
@@ -131,13 +131,13 @@ final class MemberMissionView: UIView {
     private func createMissionSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .fractionalHeight(1)
+            heightDimension: .estimated(80)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .absolute(74)
+            heightDimension: .estimated(80)
         )
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/View/MyMissionView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/View/MyMissionView.swift
@@ -138,13 +138,13 @@ final class MyMissionView: UIView {
     private func createMissionSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .fractionalHeight(1)
+            heightDimension: .estimated(80)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .absolute(74)
+            heightDimension: .estimated(80)
         )
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/DashboardHeader.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/DashboardHeader.swift
@@ -35,8 +35,10 @@ final class DashboardHeader: UICollectionReusableView {
     }
 
     private let descriptionLabel = UILabel().then {
+        $0.setTextWithLineHeight(text: nil, lineHeight: 21)
         $0.font = .pretendard(size: 14, weight: .regular)
         $0.textColor = ._000000
+        $0.numberOfLines = 0
     }
 
     private let moreButton = UIButton().then {
@@ -112,10 +114,6 @@ final class DashboardHeader: UICollectionReusableView {
 
         titleLabel.snp.makeConstraints { make in
             make.height.equalTo(36)
-        }
-
-        descriptionLabel.snp.makeConstraints { make in
-            make.height.equalTo(21)
         }
 
         moreButton.snp.makeConstraints { make in

--- a/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/GroupDashBoardView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/GroupDashBoardView.swift
@@ -313,7 +313,7 @@ final class GroupDashboardView: UIView {
     private func makeHeaderLayout() -> NSCollectionLayoutBoundarySupplementaryItem {
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .absolute(57)
+            heightDimension: .estimated(60)
         )
 
         let header = NSCollectionLayoutBoundarySupplementaryItem(

--- a/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/GroupDashBoardView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/GroupDashBoardView.swift
@@ -293,13 +293,13 @@ final class GroupDashboardView: UIView {
 
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .fractionalHeight(1)
+            heightDimension: .estimated(80)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .absolute(74)
+            heightDimension: .estimated(80)
         )
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/MissionCardCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/View/Subviews/MissionCardCell.swift
@@ -103,6 +103,7 @@ final class MissionCardCell: UICollectionViewCell {
         layer.shadowColor = UIColor.black.cgColor
         layer.shadowOpacity = 0.16
         layer.shadowRadius = 4
+        layer.shadowOffset = .zero
     }
 
     // MARK: - Set Hierarchy

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -252,10 +252,12 @@ final class HomeViewModel: ViewModelProtocol {
 
     /// [User]를 컬렉션뷰에서 사용하는 [HomeItem]으로 매핑
     private func mapMembersToHomeItems(_ members: [Member]) -> [HomeItem] {
-        members.enumerated().map { index, member in
+        let userID = state.user.value?.userID ?? ""
+        return members.enumerated().map { index, member in
+            let isUser = member.userID == userID
             let member = HomeMember(
                 memberID: member.userID,
-                nickname: member.nickname,
+                nickname: isUser ? "나" : member.nickname,
                 stickerCount: "\(member.monthSticker)개",
                 rank: index + 1,
                 profileImage: member.profileImage


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-114
  

## 📌 변경 사항 및 이유
- 기한이 오늘까지인 미션이 만료처리되는 버그 해결
- 미션 내용이 긴 경우 동적으로 셀 높이를 바꾸도록 변경
- 그 외 피그마와 일치하지 않는 디테일 조정

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro - 동적 셀 높이 | <img src = "https://github.com/user-attachments/assets/b92f029e-2221-4398-8847-e7c88ae8855a" width ="250">|
| iPhone 16 Pro - 랭킹에서 '나' 표기 | <img src = "https://github.com/user-attachments/assets/0913fa3e-6c24-4254-a1a8-ac21c3bccb86" width = "250">

## 📌 PR Point
- 닉네임 최대 길이를 제한하긴 할거지만, 나중을 위해 닉네임이 긴 경우 닉네임을 표기하는 태그만 크기가 줄어들도록 CR 우선순위를 설정하였습니다. 이 과정에서 IntrinsicContentSize를 필수적으로 설정해주어야 했는데, 사이즈 설정이 적절한지 확인 부탁드립니다.
- AssignedCell의 타입에 따라 미션 내용이 잘리는 정도를 달리해야해서 configure메서드 호출 시 셀타입을 지정하면 content의 trailing 기준점이 각각 statusView/statusButton으로 변경되는 구조를 가지고 있으나, configure 메서드의 리팩토링이 필요한 상황이라 추후에 개선하겠습니다.

## 📌 참고 사항
- 탈퇴한 멤버에 대한 닉네임 태그 처리는 DB 수정이 끝난 후에 적용하겠습니다.
