### PR TITLE
[Refactor] STAMPIT-136 스탬프판 유지보수 

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Constant.swift
@@ -61,6 +61,7 @@ enum MyPage {
         static let fontSizeSmall: CGFloat = 14
         static let fontSizeMedium: CGFloat = 16
         static let vStackSpacing: CGFloat = 6
+        static let height: CGFloat = 72
     }
 }
 

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Section.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Enum/Section.swift
@@ -59,10 +59,8 @@ enum MyPageMenu: CaseIterable {
     }
 }
 
-typealias StampBoardSection = MyPageStampBoardSection
-typealias StampBoardItem = Sticker
-
-enum MyPageStampBoardSection: Hashable {
+enum StampBoardSection: Int, Hashable {
+    case summary
     case defaultBoard
     
     var type: [[StampCellType]] {
@@ -76,21 +74,30 @@ enum MyPageStampBoardSection: Hashable {
                 [.horizontal, .horizontal, .horizontal, .horizontal, .vertical],
                 [.horizontal, .horizontal, .horizontal, .horizontal, .none],
             ]
+        default: return []
         }
     }
     
     var column: Int {
         switch self {
         case .defaultBoard: return 5
+        default: return 0
         }
     }
     
     var totalStamp: Int {
         switch self {
         case .defaultBoard: return 30
+        default: return 0
         }
     }
 }
+
+enum StampBoardItem: Hashable {
+    case summary(collected: Int, completed: Int)
+    case stickers(Sticker)
+}
+
 
 /// Dashed Line 기준
 enum StampCellType: Hashable {

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/DashedLine.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/DashedLine.swift
@@ -71,6 +71,5 @@ final class DashedLine: UIView {
         lineLayer.lineCap = .round
         lineLayer.lineWidth = 2.0
         lineLayer.lineDashPattern = [2, 4]
-        lineLayer.zPosition = -1
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoard.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoard.swift
@@ -57,13 +57,13 @@ final class StampBoard: UIView {
     private func createStampBoardLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(0.2),
-            heightDimension: .absolute(72)
+            heightDimension: .absolute(MyPage.StampBoard.height)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(72)
+            heightDimension: .absolute(MyPage.StampBoard.height)
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardCollectionView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardCollectionView.swift
@@ -9,7 +9,7 @@ import UIKit
 import Then
 import SnapKit
 
-final class StampBoard: UIView {
+final class StampBoardCollectionView: UIView {
     
     // MARK: - UI Components
     
@@ -17,9 +17,10 @@ final class StampBoard: UIView {
         frame: .zero,
         collectionViewLayout: createCompositionalLayout()
     ).then {
+        $0.register(SummaryCell.self, forCellWithReuseIdentifier: SummaryCell.identifier)
         $0.register(StampCell.self, forCellWithReuseIdentifier: StampCell.identifier)
-        $0.backgroundColor = .red50
-        $0.isScrollEnabled = false
+        $0.backgroundColor = .clear
+        $0.showsVerticalScrollIndicator = false
     }
     
     // MARK: - Initializer, Deinit, requiered
@@ -50,8 +51,35 @@ final class StampBoard: UIView {
     
     private func createCompositionalLayout() -> UICollectionViewLayout {
         UICollectionViewCompositionalLayout { [weak self] sectionIndex, environment in
-            self?.createStampBoardLayout()
+            guard let section = StampBoardSection(rawValue: sectionIndex) else {
+                return self?.createStampSummaryLayout()
+            }
+            switch section {
+            case .summary: return self?.createStampSummaryLayout()
+            case .defaultBoard: return self?.createStampBoardLayout()
+            }
         }
+    }
+    
+    private func createStampSummaryLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(72)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(72)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(top: 30, leading: 16, bottom: 0, trailing: 16)
+        return section
     }
     
     private func createStampBoardLayout() -> NSCollectionLayoutSection {
@@ -71,6 +99,7 @@ final class StampBoard: UIView {
         )
         
         let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(top: 24, leading: 36, bottom: 30, trailing: StickerType.imageSize / 3)
         return section
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardCollectionView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardCollectionView.swift
@@ -78,7 +78,12 @@ final class StampBoardCollectionView: UIView {
         )
         
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 30, leading: 16, bottom: 0, trailing: 16)
+        section.contentInsets = .init(
+            top: 30,
+            leading: 16,
+            bottom: 0,
+            trailing: 16
+        )
         return section
     }
     
@@ -99,7 +104,13 @@ final class StampBoardCollectionView: UIView {
         )
         
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 24, leading: 36, bottom: 30, trailing: StickerType.imageSize / 3)
+        let isPortrait = UIScreen.main.bounds.height > UIScreen.main.bounds.width
+        section.contentInsets = .init(
+            top: 24,
+            leading: isPortrait ? 36 : 45,
+            bottom: 30,
+            trailing: isPortrait ? StickerType.imageSize / 3 : -45
+        )
         return section
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardTab.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardTab.swift
@@ -65,7 +65,6 @@ final class StampBoardTab: UIView {
                             totalBoard: "\(completed)"
                         )
                     }
-                    
                     return cell
                     
                 case .defaultBoard:

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardTab.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampBoardTab.swift
@@ -21,8 +21,7 @@ final class StampBoardTab: UIView {
 
     // MARK: - UI Components
     
-    private let stickerSummaryView = StampSummary()
-    private let stickerBoardView = StampBoard()
+    private let stickerBoardView = StampBoardCollectionView()
     
     // MARK: - Initializer, Deinit, requiered
     
@@ -32,44 +31,10 @@ final class StampBoardTab: UIView {
         setHierarchy()
         setLayout()
         setDataSource()
-        bind()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - Bind
-    
-    private func bind() {
-        stickerSummary.bind(with: self) { owner, summary in
-            owner.stickerSummaryView.configureItem(
-                currentSticker: "\(summary.collectedSticker)",
-                totalSticker: "\(StampBoardSection.defaultBoard.totalStamp)",
-                totalBoard: "\(summary.completedBoard)\(MyPage.StampBoard.unit)"
-            )
-        }.disposed(by: disposeBag)
-    }
-    
-    // MARK: - DataSource Helper
-    
-    private func setDataSource() {
-        stickerBoardDataSource = UICollectionViewDiffableDataSource(
-            collectionView: stickerBoardView.getCollectionView(),
-            cellProvider: { collectionView, indexPath, itemIdentifier in
-                let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: StampCell.identifier,
-                    for: indexPath
-                ) as! StampCell
-                
-                let backgroundBoard = StampBoardSection.defaultBoard.type.flatMap { $0 }
-                if backgroundBoard.indices.contains(indexPath.item) {
-                    cell.configureDashedLine(with: backgroundBoard[indexPath.item])
-                }
-                cell.configureStamp(with: itemIdentifier)
-                return cell
-            })
-        stickerBoardView.setDataSource(stickerBoardDataSource)
     }
     
     // MARK: - Style Helper
@@ -78,11 +43,54 @@ final class StampBoardTab: UIView {
         backgroundColor = .red50
     }
     
+    // MARK: - DataSource Helper
+    
+    private func setDataSource() {
+        stickerBoardDataSource = UICollectionViewDiffableDataSource(
+            collectionView: stickerBoardView.getCollectionView(),
+            cellProvider: { collectionView, indexPath, itemIdentifier in
+                guard let section = StampBoardSection(rawValue: indexPath.section) else { return .init() }
+                
+                switch section {
+                case .summary:
+                    let cell = collectionView.dequeueReusableCell(
+                        withReuseIdentifier: SummaryCell.identifier,
+                        for: indexPath
+                    ) as! SummaryCell
+                    
+                    if case let .summary(collected, completed) = itemIdentifier {
+                        cell.configureItem(
+                            currentSticker: "\(collected)",
+                            totalSticker: "\(StampBoardSection.defaultBoard.totalStamp)",
+                            totalBoard: "\(completed)"
+                        )
+                    }
+                    
+                    return cell
+                    
+                case .defaultBoard:
+                    let cell = collectionView.dequeueReusableCell(
+                        withReuseIdentifier: StampCell.identifier,
+                        for: indexPath
+                    ) as! StampCell
+                    
+                    if case let .stickers(stickers) = itemIdentifier {
+                        let backgroundBoard = StampBoardSection.defaultBoard.type.flatMap { $0 }
+                        if backgroundBoard.indices.contains(indexPath.item) {
+                            cell.configureDashedLine(with: backgroundBoard[indexPath.item])
+                        }
+                        cell.configureStamp(with: stickers)
+                    }
+                    return cell
+                }
+            })
+        stickerBoardView.setDataSource(stickerBoardDataSource)
+    }
+    
     // MARK: - Hierarchy Helper
     
     private func setHierarchy() {
         [
-            stickerSummaryView,
             stickerBoardView
         ]
             .forEach { addSubview($0) }
@@ -91,16 +99,8 @@ final class StampBoardTab: UIView {
     // MARK: - Layout Helper
     
     private func setLayout() {
-        stickerSummaryView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(30)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
-        }
-        
         stickerBoardView.snp.makeConstraints {
-            $0.top.equalTo(stickerSummaryView.snp.bottom).offset(34)
-            $0.leading.equalToSuperview().inset(36)
-            $0.trailing.equalToSuperview().inset(StickerType.imageSize / 3)
-            $0.bottom.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampCell.swift
@@ -58,13 +58,16 @@ final class StampCell: UICollectionViewCell {
         }
         
         horizontalLine.snp.makeConstraints {
-            $0.width.equalToSuperview()
-            $0.leading.top.equalToSuperview().offset(StickerType.imageSize / 2)
+            $0.size.equalToSuperview()
+            $0.top.equalToSuperview().offset(StickerType.imageSize / 2)
+            $0.trailing.equalToSuperview()
         }
         
         verticalLine.snp.makeConstraints {
-            $0.height.equalTo(StickerType.imageSize)
-            $0.leading.top.equalToSuperview().offset(StickerType.imageSize / 2)
+            $0.height.equalTo(MyPage.StampBoard.height)
+            $0.width.equalTo(StickerType.imageSize)
+            $0.leading.equalToSuperview().offset(StickerType.imageSize / 2)
+            $0.top.equalToSuperview()
         }
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampCell.swift
@@ -58,7 +58,7 @@ final class StampCell: UICollectionViewCell {
         }
         
         horizontalLine.snp.makeConstraints {
-            $0.width.equalTo(StickerType.imageSize)
+            $0.width.equalToSuperview()
             $0.leading.top.equalToSuperview().offset(StickerType.imageSize / 2)
         }
         

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/StampCell.swift
@@ -58,14 +58,15 @@ final class StampCell: UICollectionViewCell {
         }
         
         horizontalLine.snp.makeConstraints {
-            $0.size.equalToSuperview()
+            $0.height.equalTo(3)
+            $0.width.equalToSuperview()
             $0.top.equalToSuperview().offset(StickerType.imageSize / 2)
             $0.trailing.equalToSuperview()
         }
         
         verticalLine.snp.makeConstraints {
             $0.height.equalTo(MyPage.StampBoard.height)
-            $0.width.equalTo(StickerType.imageSize)
+            $0.width.equalTo(3)
             $0.leading.equalToSuperview().offset(StickerType.imageSize / 2)
             $0.top.equalToSuperview()
         }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/SummaryCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/View/StampBoard/SummaryCell.swift
@@ -1,16 +1,20 @@
 //
-//  StampSummary.swift
+//  SummaryCell.swift
 //  StampIt-Project
 //
-//  Created by kingj on 6/10/25.
+//  Created by kingj on 6/23/25.
 //
 
 import UIKit
 import Then
 import SnapKit
 
-final class StampSummary: UIView {
+final class SummaryCell: UICollectionViewCell {
     
+    // MARK: - Properties
+    
+    static let identifier = "SummaryCell"
+
     // MARK: - UI Components
     
     /// Vertical Stack View - 내가 모은 스탬프
@@ -158,8 +162,8 @@ final class StampSummary: UIView {
     
     private func setLayout() {
         hStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(12)
-            $0.height.equalTo(50)
+            $0.directionalHorizontalEdges.equalToSuperview()
+            $0.directionalVerticalEdges.equalToSuperview()
         }
         
         divider.snp.makeConstraints {

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -80,15 +80,14 @@ final class MyPageViewController: UIViewController {
                 owner.updateSelectedTab(selected: tab)
             }.disposed(by: disposeBag)
         
-        viewModel.state.stickers
-            .bind(with: self) { owner, stickers in
-                owner.updateUI(with: stickers)
-            }.disposed(by: disposeBag)
-        
-        viewModel.state.stickerSummary
-            .bind(with: self) { owner, summary in
-                owner.stampBoardView.stickerSummary.accept(summary)
-            }.disposed(by: disposeBag)
+        Observable.combineLatest(
+            viewModel.state.stickerSummary,
+            viewModel.state.stickers
+        )
+        .bind(with: self) { owner, combined in
+            let (summary, stickers) = combined
+            owner.updateSnapshot(summary: summary, stickers: stickers)
+        }.disposed(by: disposeBag)
         
         viewModel.state.user
             .compactMap { $0 }
@@ -177,10 +176,25 @@ final class MyPageViewController: UIViewController {
 
     // MARK: - Snapshot
     
-    private func updateUI(with stickers: [Sticker]) {
+    private func updateSnapshot(
+        summary: (collected: Int, completed: Int),
+        stickers: [Sticker]
+    ) {
         var snapshot = NSDiffableDataSourceSnapshot<StampBoardSection, StampBoardItem>()
+        snapshot.appendSections([.summary])
+        snapshot.appendItems(
+            [.summary(
+                collected: summary.collected,
+                completed: summary.completed
+            )],
+            toSection: .summary
+        )
+        
         snapshot.appendSections([.defaultBoard])
-        snapshot.appendItems(stickers, toSection: .defaultBoard)
+        snapshot.appendItems(
+            stickers.map { .stickers($0) } ,
+            toSection: .defaultBoard
+        )
         stampBoardView.stickerBoardDataSource.apply(snapshot, animatingDifferences: false)
     }
     

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -147,8 +147,7 @@ final class MyPageViewController: UIViewController {
     
     private func setLayout() {
         navigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.directionalHorizontalEdges.equalToSuperview()
+            $0.top.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
         }
         
         stampBoardView.snp.makeConstraints {

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -48,7 +48,7 @@ final class MyPageViewModel: ViewModelProtocol {
     // MARK: - Initializer, Deinit, requiered
     
     init(
-        myPageUseCase: MyPageUseCase, 
+        myPageUseCase: MyPageUseCase,
         accountManageUseCase: AccountManageUseCaseProtocol
     ) {
         self.myPageUseCase = myPageUseCase
@@ -85,41 +85,49 @@ final class MyPageViewModel: ViewModelProtocol {
             }.disposed(by: disposeBag)
     }
     
-    private func fetchStickersByPin(userId: String, pinNumber: Int) {
-        myPageUseCase.fetchStickersByPin(userId: userId, pinNumber: pinNumber)
-            .subscribe(
-                with: self,
-                onNext: { owner, stickers in
-                    owner.state.stickers.accept(
-                        owner.makeZigzagOrder(from: stickers, columns: StampBoardSection.defaultBoard.column)
-                    )
-                }, onError: { owner, error in
-                    owner.state.stickers.accept(
-                        owner.makeZigzagOrder(from: [], columns: StampBoardSection.defaultBoard.column)
-                    )
-                }
-            ).disposed(by: disposeBag)
-    }
-    
     private func bindStickerSummaryData() {
         guard let user = state.user.value else { return }
         
+        /// stickerSummary, stickers 가 동시에 변경
         myPageUseCase.fetchStickerCount(userId: user.userID)
-            .subscribe(with: self) { owner, sticker in
-                let totalSticker = StampBoardSection.defaultBoard.totalStamp
-                let collectedSticker = Int(sticker % totalSticker)
-                let completedBoard = Int(sticker / totalSticker)
+            .flatMapLatest { [weak self] count -> Observable<(Int, [Sticker])> in
+                guard let self else { return .empty() }
                 
+                let completedBoard = Int(count / StampBoardSection.defaultBoard.totalStamp)
+                let pinNumber = completedBoard + 1
+                
+                return self.myPageUseCase.fetchStickersByPin(
+                    userId: user.userID,
+                    pinNumber: pinNumber
+                ).map { stickers in
+                    return (count, stickers)
+                }
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, result in
+                let (count, stickers) = result
+                
+                let totalSticker = StampBoardSection.defaultBoard.totalStamp
+                let collectedSticker = Int(count % totalSticker)
+                let completedBoard = Int(count / totalSticker)
+                
+                /// stickerSummary 업데이트
                 owner.state.stickerSummary.accept((
                     collected: collectedSticker,
                     completed: completedBoard
                 ))
                 
-                owner.fetchStickersByPin(
-                    userId: user.userID,
-                    pinNumber: completedBoard + 1
-                )
+                /// Zigzag 변환후 stickers 업데이트
+                owner.updateStickerZigzag(stickers)
             }.disposed(by: disposeBag)
+    }
+    
+    private func updateStickerZigzag(_ stickers: [Sticker]) {
+        let zigzagged = makeZigzagOrder(
+            from: stickers,
+            columns: StampBoardSection.defaultBoard.column
+        )
+        state.stickers.accept(zigzagged)
     }
     
     private func makeZigzagOrder(from stickers: [Sticker], columns: Int) -> [Sticker] {

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -30,7 +30,7 @@ final class MyPageViewModel: ViewModelProtocol {
         let user = BehaviorRelay<User?>(value: nil)
         let stickers = BehaviorRelay<[Sticker]>(value: [])
         let tabType = BehaviorRelay<TabType>(value: .stampBoard)
-        let stickerSummary = BehaviorRelay<(collectedSticker: Int, completedBoard: Int)>(value: (.zero, .zero))
+        let stickerSummary = BehaviorRelay<(collected: Int, completed: Int)>(value: (.zero, .zero))
         let isLoading = BehaviorRelay<Bool>(value: false)
         let alertMessage = PublishRelay<String>()
         let shouldNavigateToLogin = PublishRelay<Void>()
@@ -111,8 +111,8 @@ final class MyPageViewModel: ViewModelProtocol {
                 let completedBoard = Int(sticker / totalSticker)
                 
                 owner.state.stickerSummary.accept((
-                    collectedSticker: collectedSticker,
-                    completedBoard: completedBoard
+                    collected: collectedSticker,
+                    completed: completedBoard
                 ))
                 
                 owner.fetchStickersByPin(


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-136

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 스티커가 추가되었을 때 점선이 스티커 위로 보이는 이슈
- landscape 모드, 아이패드 등 넓은 화면에서는 점선이 이어지지 않는 이슈
- 스티커 추가되었을 때 요약 뷰에서 바로 업데이트 되지 않는 이슈
  - 요약뷰 데이터는 addSnapshotListener 로 받아오고 있지 않아서 변경될 예정 (부용님)
  - 변경되면 바로 적용되도록 구현 완료
  - addSnapshotListener 로 변경하여 테스트 완료
- 스탬프판 요약뷰까지 CollectionView 로 리팩토링
- landscape 모드 적용시, 스티커판이 가운데 오도록 조정

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |   스크린샷(또는 GIF)   |
| :-------------: | :----------: | :----------: |
| iPhone 16 Pro | 요약, 스티커 데이터 업데이트 <br> <br> <br>  <img src = "https://github.com/user-attachments/assets/5bc73610-4ece-43f8-b724-5e5e8fe82ea9" width ="250">|  <- 미션 완료 클릭시 <br> <br> <br> <br> <img src = "https://github.com/user-attachments/assets/5b8dd3b2-3c50-4daf-b48e-488c729a30e5" width ="250">|


|    실행 기기    |   스크린샷(또는 GIF)   | 
| :-------------: | :----------: | 
| iPhone 16 Pro  <br>  landscape 모드 적용시, <br> 스티커판이 가운데 오도록 조정 |  <img src = "https://github.com/user-attachments/assets/8b94ecd7-4b92-4dab-a3b2-a7518346338e" width ="500">|
| iPhone 13 mini  <br>  landscape 모드 적용시, <br> 스티커판이 가운데 오도록 조정 |  <img src = "https://github.com/user-attachments/assets/58568564-6b7b-455c-afc1-d27d076e963b" width ="500">| 


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 스티커 추가되었을 때 요약 뷰에서 바로 업데이트 될 때 flatmapLatest 사용한 부분 
- 스탬프판 요약뷰까지 CollectionView 로 리팩토링

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 참고로, landscape 모드 적용하면 navigationbar 사용할 때 superview 까지 보이는 상황이라서 
   `directionalHorizontalEdges` 도 safeAreaLayout 사용해야합니다. 홈, 미션 화면에서 변경 부탁드립니다. 
   아래 사진은 superview 까지 보이는 사진이니 참고해주세요
   ```swift
    navigationBar.snp.makeConstraints {
            $0.top.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
        }
   ```

|   마이페이지탭 -  safeAreaLayout 적용  |
| :----------: |
| <img src = "https://github.com/user-attachments/assets/1bd71451-ff07-4a95-966c-f6a50337ae6f" width ="500"> | 


|   미션탭  |
| :----------: |
| <img src = "https://github.com/user-attachments/assets/6c83973f-4274-4852-ae0f-480b96e7d724" width ="500"> | 

|   홈탭  |
| :----------: |
| <img src = "https://github.com/user-attachments/assets/630e55a3-7e9a-4238-8922-ebd121aea076" width ="500"> | 


- 크롬 꺼져서 다시 작성했습니다 -.-🔥