### PR TITLE
[Refactor] STAMPIT-164 미션/내정보수정 화면 리팩토링

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -28,7 +28,7 @@ final class AssignMissionViewController: UIViewController {
     // 멤버 선택 버튼
     private lazy var memberSelectionButton = UIButton().then {
         $0.titleLabel?.numberOfLines = 1
-        $0.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray800)
+        $0.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray200)
         $0.addTarget(self, action: #selector(dropdown), for: .touchUpInside)
     }
     
@@ -248,14 +248,12 @@ final class AssignMissionViewController: UIViewController {
         isDropdown.toggle()
         
         if isDropdown {
-            memberSelectionButton.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray200)
             dropdownView.alpha = 0
             dropdownView.isHidden = false
             UIView.animate(withDuration: 0.25) { [weak self] in
                 self?.dropdownView.alpha = 1
             }
         } else {
-            memberSelectionButton.configuration = configureButton(title: "멤버 선택하기", titleColor: .gray800)
             UIView.animate(withDuration: 0.25) { [weak self] in
                 self?.dropdownView.alpha = 0
             } completion: { [weak self] _ in

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 import RxSwift
 import RxCocoa
 import SnapKit
@@ -51,27 +52,13 @@ final class AssignMissionViewController: UIViewController {
         $0.distribution = .equalSpacing
     }
     
-    private let dueDateLabel = UILabel().then {
-        $0.text = "미션 기한"
-        $0.font = .pretendard(size: 16, weight: .regular)
-        $0.textColor = .gray800
-    }
-    
-    // 날짜 선택 피커
-    private let dueDatePicker = UIDatePicker().then {
-        $0.preferredDatePickerStyle = .compact
-        $0.datePickerMode = .date
-        $0.locale = Locale(identifier: "ko_KR")
-        $0.minimumDate = Date()
-        $0.tintColor = .red400
-    }
-    
-    // dueDateLabel + dueDatePicker
-    private let dueDateStackView = UIStackView().then {
-        $0.axis = .horizontal
-        $0.alignment = .center
-        $0.distribution = .equalSpacing
-    }
+    private lazy var dueDateView: UIView = {
+        let hostingController = UIHostingController(rootView: DueDateView { [weak self] selectedDate in
+            self?.viewModel.action.accept(.didSelectDueDate(selectedDate))
+        })
+        hostingController.view.backgroundColor = .clear
+        return hostingController.view
+    }()
     
     // 미션 전달하기 버튼(화면 맨 아래)
     private let assignButton = DefaultButton(type: .send).then {
@@ -116,16 +103,12 @@ final class AssignMissionViewController: UIViewController {
         view.backgroundColor = .white
         
         // dropdownView는 보여질 때 일부 화면이 가려지므로(예: dueDateStackView) 마지막에 서브 뷰로 추가
-        [navigationBar, missionTitleLabel, memberStackView, dueDateStackView, assignButton, dropdownView].forEach {
+        [navigationBar, missionTitleLabel, memberStackView, dueDateView, assignButton, dropdownView].forEach {
             view.addSubview($0)
         }
         
         [memberLabel, memberSelectionButton].forEach {
             memberStackView.addArrangedSubview($0)
-        }
-        
-        [dueDateLabel, dueDatePicker].forEach {
-            dueDateStackView.addArrangedSubview($0)
         }
     }
     
@@ -145,7 +128,7 @@ final class AssignMissionViewController: UIViewController {
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
-        dueDateStackView.snp.makeConstraints {
+        dueDateView.snp.makeConstraints {
             $0.top.equalTo(memberStackView.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
@@ -156,7 +139,7 @@ final class AssignMissionViewController: UIViewController {
         }
         
         memberSelectionButton.snp.makeConstraints {
-            $0.width.equalTo(140)
+            $0.width.equalTo(144)
         }
         
         dropdownView.snp.makeConstraints {
@@ -199,15 +182,6 @@ final class AssignMissionViewController: UIViewController {
                 assignButton.isEnabled = true // 미션 전달하기 버튼 활성화
                 dropdownView.isHidden = true
                 isDropdown = false
-            }
-            .disposed(by: disposeBag)
-        
-        // 사용자가 날짜 선택 시
-        dueDatePicker.rx.date
-            .asDriver(onErrorDriveWith: .empty())
-            .distinctUntilChanged()
-            .drive { [weak self] date in
-                self?.viewModel.action.accept(.didSelectDueDate(date))
             }
             .disposed(by: disposeBag)
         

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -97,7 +97,7 @@ final class MissionListViewController: UIViewController {
         
         searchBar.snp.makeConstraints {
             $0.top.equalTo(navigationBar.snp.bottom)
-            $0.horizontalEdges.equalToSuperview()
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide.snp.horizontalEdges).inset(8)
         }
         
         collectionView.snp.makeConstraints {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -26,6 +26,7 @@ final class MissionListViewController: UIViewController {
     
     private lazy var tableView = UITableView().then {
         $0.register(MissionListCell.self, forCellReuseIdentifier: MissionListCell.reuseIdentifier)
+        $0.separatorColor = .gray50
         $0.keyboardDismissMode = .onDrag
         $0.delegate = self
     }
@@ -102,7 +103,7 @@ final class MissionListViewController: UIViewController {
         collectionView.snp.makeConstraints {
             $0.top.equalTo(searchBar.snp.bottom).offset(8)
             $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide.snp.horizontalEdges)
-            $0.height.equalTo(36)
+            $0.height.equalTo(32)
         }
         
         tableView.snp.makeConstraints {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/DueDateView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/DueDateView.swift
@@ -1,0 +1,56 @@
+//
+//  DueDateView.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 6/25/25.
+//
+
+import SwiftUI
+
+struct DueDateView: View {
+    @State private var showCalendar = false
+    @State private var selectedDate = Date()
+    
+    let onChange: (Date) -> Void
+    
+    private var formattedDate: String {
+        selectedDate.formatted(.dateTime.year().month().day().locale(Locale(identifier: "ko_KR")))
+    }
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text("미션 기한")
+                    .font(.custom("Pretendard", size: 16))
+                    .foregroundColor(.gray800)
+                Spacer()
+                Button {
+                    withAnimation {
+                        showCalendar.toggle()
+                    }
+                } label: {
+                    Text(formattedDate)
+                        .font(.custom("Pretendard", size: 16))
+                        .foregroundColor(.gray800)
+                        .padding(.vertical, 7)
+                        .padding(.horizontal, 14)
+                        .background(.gray25)
+                        .cornerRadius(6)
+                }
+            }
+            
+            DatePicker("", selection: $selectedDate, in: Date()..., displayedComponents: [.date])
+                .datePickerStyle(.graphical)
+                .labelsHidden()
+                .frame(minHeight: 320)
+                .opacity(showCalendar ? 1 : 0)
+        }
+        .onChange(of: selectedDate) { newValue in
+            onChange(newValue)
+        }
+    }
+}
+
+#Preview {
+    DueDateView(onChange: { _ in })
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/DueDateView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/DueDateView.swift
@@ -38,6 +38,7 @@ struct DueDateView: View {
                         .cornerRadius(6)
                 }
             }
+            .padding(.bottom)
             
             DatePicker("", selection: $selectedDate, in: Date()..., displayedComponents: [.date])
                 .datePickerStyle(.graphical)

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
@@ -14,6 +14,7 @@ final class MissionListCell: UITableViewCell {
     
     private let label = UILabel().then {
         $0.font = .pretendard(size: 16, weight: .regular)
+        $0.textColor = .gray800
         $0.numberOfLines = 0
     }
     
@@ -33,7 +34,7 @@ final class MissionListCell: UITableViewCell {
     
     private func setConstraints() {
         label.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(12)
+            $0.verticalEdges.equalToSuperview().inset(16)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
     }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -171,7 +171,7 @@ final class EditProfileViewController: UIViewController {
         collectionView.snp.makeConstraints {
             $0.top.equalTo(profileImageLabel.snp.bottom).offset(8)
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(64)
+            $0.height.equalTo(60)
         }
         
         nicknameStackView.snp.makeConstraints {


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-164

## 📌 변경 사항 및 이유
- 피그마 수정사항 반영(폰트, 라인 굵기/색상 등)
- 컬렉션 뷰 위아래 스크롤 조금 되는거 보완
- 미션 기한 date picker 변경: UIKit UIDatePicker -> SwiftUI 사용

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-26 at 09 03 31](https://github.com/user-attachments/assets/e3310a1f-c5c9-47fc-a2c9-77df06f57c79)|

## 📌 PR Point
- date picker 뭐가 바뀐건지 모르실텐데, 바로 위에 있는 멤버 선택 버튼과 길이가 같아야 하는데 그걸 못하고 있었습니다...

## 📌 참고 사항
- 미션 주기 화면 열릴 때 레이아웃 관련 경고(UICalendarView's height is smaller than it can render its content in; defaulting to the minimum height.)가 뜹니다. 튜터님이 이건 무시해도 될거 같다고 하셔서 일단 PR 합니다.
- SwiftUI date picker가 UICalendarView를 래핑해서 동작하는거 같습니다. 다은님 말씀하신 방식으로 UIDatePicker 대신 UICalendarView를 트리거해서 여는 방식도 가능할지 모르겠다는 생각이 드네요.