### PR TITLE
[Fix] STAMPIT-129 - 홈화면에서 미완료 미션 조회할 수 있도록 미션 쿼리, 매니저 수정

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionManager.swift
@@ -243,12 +243,12 @@ final class MissionManager: MissionManagerProtocol {
             result = result.whereField("assignedBy", in: assignerIds)
         }
         
-        if let isCompleted = missionQuery.isCompleted {
-            result = result.whereField("isCompleted", isEqualTo: isCompleted)
+        if let status = missionQuery.status {
+            result = result.whereField("status", isEqualTo: status)
         }
         
         if let createdAfter = missionQuery.createdAfter {
-            result = result.whereField("createdAt", isGreaterThan: Timestamp(date: createdAfter))
+            result = result.whereField("createDate", isGreaterThan: Timestamp(date: createdAfter))
         }
         
         if let dueDate = missionQuery.dueDate {
@@ -273,7 +273,7 @@ final class MissionManager: MissionManagerProtocol {
         return observeList(query: .byGroup(groupId))
     }
     
-    /// 할당된 미션 목록 조회
+    /// 할당된 미션 목록 조회 (전체)
     func fetchMissions(to assigneeId: String?, by assignerId: String?, ofGroup groupId: String) -> Observable<[MissionFirestore]> {
         let query: MissionQuery
         
@@ -285,6 +285,12 @@ final class MissionManager: MissionManagerProtocol {
             query = .byGroup(groupId)
         }
         
+        return observeList(query: query)
+    }
+    
+    /// 할당된 미완료 미션만 조회 (홈화면용)
+    func fetchIncompleteMissions(to assigneeId: String, ofGroup groupId: String) -> Observable<[MissionFirestore]> {
+        let query = MissionQuery.incompleteByAssignee(assigneeId, groupId: groupId)
         return observeList(query: query)
     }
     

--- a/StampIt-Project/StampIt-Project/Data/Entities/Query/MissionQuery.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/Query/MissionQuery.swift
@@ -13,21 +13,26 @@ struct MissionQuery {
     let groupIds: [String]?
     let assigneeIds: [String]?
     let assignerIds: [String]?
-    let isCompleted: Bool?
+    let status: String?
     let createdAfter: Date?
     let dueDate: Date?
     let orderBy: QueryOrder?
     let limit: Int?
     
     static func byGroup(_ groupId: String) -> MissionQuery {
-        return MissionQuery(missionIds: nil, groupIds: [groupId], assigneeIds: nil, assignerIds: nil, isCompleted: nil, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil)
+        return MissionQuery(missionIds: nil, groupIds: [groupId], assigneeIds: nil, assignerIds: nil, status: nil, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil)
     }
     
     static func byAssignee(_ assigneeId: String, groupId: String) -> MissionQuery {
-        return MissionQuery(missionIds: nil, groupIds: [groupId], assigneeIds: [assigneeId], assignerIds: nil, isCompleted: nil, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil)
+        return MissionQuery(missionIds: nil, groupIds: [groupId], assigneeIds: [assigneeId], assignerIds: nil, status: nil, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil)
     }
     
     static func byAssigner(_ assignerId: String, groupId: String) -> MissionQuery {
-        return MissionQuery(missionIds: nil, groupIds: [groupId], assigneeIds: nil, assignerIds: [assignerId], isCompleted: nil, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil)
+        return MissionQuery(missionIds: nil, groupIds: [groupId], assigneeIds: nil, assignerIds: [assignerId], status: nil, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil)
+    }
+    
+    /// 특정 사용자의 미완료 미션만 조회
+    static func incompleteByAssignee(_ assigneeId: String, groupId: String) -> MissionQuery { return MissionQuery( missionIds: nil, groupIds: [groupId], assigneeIds: [assigneeId], assignerIds: nil, status: MissionStatus.assigned.rawValue, createdAfter: nil, dueDate: nil, orderBy: nil, limit: nil
+        )
     }
 }


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-129 (HotFix)

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 쿼리 DB와 맞춰서 isCompleted가 아니라 status로 수정하고, 미완료 미션만 조회할 수 있게 쿼리 분리해뒀습니다.
2. 홈화면(카드컬렉션뷰셀)에서 사용할 수 있게 할당된 미완료 미션만 조회하는 매니저 메서드(fetchIncompleteMissions) 만들었습니다

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/2e6321f4-9c50-427d-9d9b-fd8a24a22ea1" width ="250">|

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
Home에서 미션 가져올때 발생하는 문제 해결을 위해 쿼리와 매니저 수정했습니다.
다은님은 수정 중에 다른 문제 생기시면 말씀해주세요!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
아직 UseCase, Repository에서 전체 미션만 조회하고 있어서 미완료/완료 미션 전체가 보입니다.
카드뷰셀만 미완료 미션을 가져오는 메서드로 변경하시면 될 것 같습니다.