### PR TITLE
[Feat] STAMPIT-176 미션 화면/내정보수정 화면 리팩토링

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/DueDateView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/DueDateView.swift
@@ -32,8 +32,8 @@ struct DueDateView: View {
                     Text(formattedDate)
                         .font(.custom("Pretendard", size: 16))
                         .foregroundColor(.gray800)
+                        .frame(width: 144)
                         .padding(.vertical, 7)
-                        .padding(.horizontal, 14)
                         .background(.gray25)
                         .cornerRadius(6)
                 }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -211,6 +211,8 @@ final class EditProfileViewController: UIViewController {
     
     private func setNavigationBar() {        
         navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
     
     private func setButtonAction() {
@@ -446,5 +448,12 @@ extension EditProfileViewController {
     
     enum Item: Hashable {
         case image(String)
+    }
+}
+
+extension EditProfileViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // navigationController의 viewControllers가 2개 이상일 때만 pop 허용
+        return navigationController?.viewControllers.count ?? 0 > 1
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -113,6 +113,7 @@ final class EditProfileViewController: UIViewController {
     }
     
     deinit {
+        NotificationCenter.default.removeObserver(self)
         print("editProfileViewController deinit")
     }
     
@@ -132,6 +133,9 @@ final class EditProfileViewController: UIViewController {
         bind()
         
         setupSelectedProfileImage()
+        
+        setupKeyboardNotification()
+        setTapGesture()
         
         viewModel.action.accept(.onAppear)
     }
@@ -382,6 +386,55 @@ final class EditProfileViewController: UIViewController {
     private func dismiss() {
         navigationController?.popViewController(animated: true)
         print("dismiss")
+    }
+    
+    // 키보드 올라왔을 때 버튼 가리는 현상 방지
+    private func setupKeyboardNotification() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillShow(_:)),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillHide(_:)),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
+    }
+    
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { return }
+        
+        let keyboardTopY = keyboardFrame.origin.y
+        let buttonBottomY = editButton.convert(editButton.bounds, to: view.window).maxY
+        
+        // 버튼이 키보드에 가려지는 경우만 이동
+        if buttonBottomY > keyboardTopY {
+            let offset = buttonBottomY - keyboardTopY + 16
+            UIView.animate(withDuration: duration) {
+                self.view.transform = CGAffineTransform(translationX: 0, y: -offset)
+            }
+        }
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { return }
+        
+        UIView.animate(withDuration: duration) {
+            self.view.transform = .identity
+        }
+    }
+    
+    // 화면을 아무데나 터치하면 키보드 내려감
+    private func setTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-176

## 📌 변경 사항 및 이유
- 미션주기 날짜 선택 시, 날짜에 따라 박스크기가 바뀌는 문제점 해결
- 내 정보 수정 시, 키보드 올라오면 버튼이 가려지는 문제점 해결

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro(날짜에 따라 박스 크기 변경 문제 해결) |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-27 at 14 16 30](https://github.com/user-attachments/assets/32edab27-7465-4d33-9912-65abf0f4b662)|
| iPhone 16 Pro(키보드 올라오면 버튼 가려짐 해결)|![Simulator Screen Recording - iPhone 16 Pro - 2025-06-27 at 14 18 48](https://github.com/user-attachments/assets/44c6bf37-7b46-4ce1-a5b4-d352c7103dc4)|
| iPhone SE(키보드 올라오면 버튼 가려짐 해결) |![Simulator Screen Recording - iPhone SE (3rd generation) - 2025-06-27 at 14 20 03](https://github.com/user-attachments/assets/d5ebfeb6-f8d9-46e4-8b64-bc2d0b3e6a82)|

## 📌 PR Point
없음

## 📌 참고 사항
- 현재 키보드 올라오면 토스트 메시지 가려집니다. 토스트 메시지가 많은 곳에서 쓰이므로 얘기가 필요할거 같습니다.