### PR TITLE
[Feat] stampit 175 초대하기 자동 복사 로직 수정 및 초대받기 화면 키보드 관련 로직 추가

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/GroupMemberManage/ViewController/GroupMemberCardCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/GroupMemberManage/ViewController/GroupMemberCardCell.swift
@@ -50,7 +50,7 @@ final class GroupMemberCardCell: UICollectionViewCell {
     }
 
     private let dateLabel = UILabel().then {
-        $0.font = .pretendard(size: 13, weight: .regular)
+        $0.font = .pretendard(size: 14, weight: .regular)
         $0.textColor = .gray500
         $0.numberOfLines = 1
         $0.lineBreakMode = .byTruncatingTail

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/ReceiveInviteViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/ReceiveInviteViewController.swift
@@ -15,10 +15,19 @@ import RxCocoa
 /// 그룹 초대 코드 입력 화면
 final class ReceiveInviteViewController: UIViewController {
 
+    // MARK: - Constants
+    private enum Constants {
+        static let keyboardOffset: CGFloat = 40
+        static let toastDelay: TimeInterval = 0.3
+        static let animationDuration: TimeInterval = 0.2
+        static let rootTransitionDuration: TimeInterval = 0.15
+    }
+
     // MARK: - properties
 
     private let viewModel: ReceiveInviteViewModel
     private let disposeBag = DisposeBag()
+    private var isKeyboardVisible = false
 
     init(viewModel: ReceiveInviteViewModel) {
         self.viewModel = viewModel
@@ -60,6 +69,7 @@ final class ReceiveInviteViewController: UIViewController {
         $0.autocorrectionType = .no
         $0.autocapitalizationType = .none
         $0.clearButtonMode = .whileEditing
+        $0.enablesReturnKeyAutomatically = true
     }
 
     private let stackView = UIStackView().then {
@@ -79,14 +89,14 @@ final class ReceiveInviteViewController: UIViewController {
 
     private let enterButton = DefaultButton(type: .enter)
 
-
-
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         setupLayout()
         bindViewModel()
         setupNavigation()
+        setupKeyboardDismiss()
+        setupKeyboardNotifications()
         textField.delegate = self
 
     }
@@ -152,13 +162,22 @@ final class ReceiveInviteViewController: UIViewController {
 
     // MARK: - Bind
     private func bindViewModel() {
-
+        bindTextField()
+        bindEnterButton()
+        bindNavigation()
+        bindMessages()
+        bindInviteCompletion()
+    }
+    
+    private func bindTextField() {
         textField.rx.text.orEmpty
             .distinctUntilChanged()
             .map { ReceiveInviteViewModel.Action.codeChanged($0) }
             .bind(to: viewModel.action)
             .disposed(by: disposeBag)
-
+    }
+    
+    private func bindEnterButton() {
         enterButton.rx.tap
             .map { ReceiveInviteViewModel.Action.enterButtonTapped }
             .bind(to: viewModel.action)
@@ -167,22 +186,40 @@ final class ReceiveInviteViewController: UIViewController {
         viewModel.state.isEnterButtonEnabled
             .bind(to: enterButton.rx.isEnabled)
             .disposed(by: disposeBag)
-
+    }
+    
+    private func bindNavigation() {
         navigationBar.backTapped
             .bind(with: self) { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
             }.disposed(by: disposeBag)
-
+    }
+    
+    private func bindMessages() {
         viewModel.state.showMessage
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] (type, message) in
                 guard let self = self else { return }
-                let toastView = ToastView()
-
-                toastView.show(in: self.view, message: message, type: type)
+                
+                // 키보드가 올라와 있으면 먼저 내리기
+                if self.isKeyboardVisible {
+                    self.textField.resignFirstResponder()
+                    
+                    // 키보드가 완전히 내려간 후 토스트 표시
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Constants.toastDelay) {
+                        let toastView = ToastView()
+                        toastView.show(in: self.view, message: message, type: type)
+                    }
+                } else {
+                    // 키보드가 내려가 있으면 바로 토스트 표시
+                    let toastView = ToastView()
+                    toastView.show(in: self.view, message: message, type: type)
+                }
             })
             .disposed(by: disposeBag)
-
+    }
+    
+    private func bindInviteCompletion() {
         viewModel.state.didCompleteInvite
             .bind(with: self) { owner, _ in
                 let container = DIContainer.shared
@@ -191,13 +228,73 @@ final class ReceiveInviteViewController: UIViewController {
                 let tabBarController = MainTabBarController(container: container)
                 tabBarController.selectedIndex = 0
 
-                WindowTransitionManager.shared.changeRootViewController(to: tabBarController, duration: 0.15)
+                WindowTransitionManager.shared.changeRootViewController(to: tabBarController, duration: Constants.rootTransitionDuration)
                 // 현재 navigation stack에서 pop
                 owner.navigationController?.popToRootViewController(animated: true)
-                //스택에 쌓인 루트 뷰를 안보여주고 없애는 법
-
             }
             .disposed(by: disposeBag)
+    }
+
+    private func setupKeyboardDismiss() {
+        let tapGesture = UITapGestureRecognizer()
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+        
+        tapGesture.rx.event
+            .subscribe(onNext: { [weak self] _ in
+                self?.dismissKeyboard()
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    private func setupKeyboardNotifications() {
+        NotificationCenter.default.rx.notification(UIResponder.keyboardWillShowNotification)
+            .subscribe(onNext: { [weak self] notification in
+                self?.handleKeyboardWillShow(notification)
+            })
+            .disposed(by: disposeBag)
+        
+        NotificationCenter.default.rx.notification(UIResponder.keyboardWillHideNotification)
+            .subscribe(onNext: { [weak self] notification in
+                self?.handleKeyboardWillHide(notification)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func handleKeyboardWillShow(_ notification: Notification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else {
+            return
+        }
+        
+        isKeyboardVisible = true
+        
+        let keyboardTopY = keyboardFrame.minY
+        let buttonBottomY = enterButton.frame.maxY
+        
+        // 버튼이 키보드에 가려지는 경우만 이동
+        if buttonBottomY > keyboardTopY {
+            let offset = buttonBottomY - keyboardTopY + Constants.keyboardOffset
+            UIView.animate(withDuration: duration) {
+                self.view.transform = CGAffineTransform(translationX: 0, y: -offset)
+            }
+        }
+    }
+
+    private func handleKeyboardWillHide(_ notification: Notification) {
+        guard let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else {
+            return
+        }
+        
+        isKeyboardVisible = false
+        
+        UIView.animate(withDuration: duration) {
+            self.view.transform = .identity
+        }
     }
 }
 
@@ -206,7 +303,7 @@ extension ReceiveInviteViewController: UITextFieldDelegate {
 
     /// axis를 vertical로 변경
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        UIView.animate(withDuration: 0.2) {
+        UIView.animate(withDuration: Constants.animationDuration) {
             self.stackView.axis = .vertical
             self.stackView.spacing = 5
             self.stackView.alignment = .fill
@@ -220,7 +317,7 @@ extension ReceiveInviteViewController: UITextFieldDelegate {
     /// axis를 horizontal로 변경
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.text?.isEmpty ?? true {
-            UIView.animate(withDuration: 0.2) {
+            UIView.animate(withDuration: Constants.animationDuration) {
                 self.stackView.axis = .horizontal
                 self.stackView.spacing = 8
                 self.stackView.alignment = .center

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/SendInviteViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/SendInviteViewController.swift
@@ -158,12 +158,12 @@ final class SendInviteViewController: UIViewController{
             .bind(to: inviteCodeLabel.rx.text)
             .disposed(by: disposeBag)
 
-        viewModel.state.inviteCode
+        // 복사 성공 시그널을 구독하여 실제 클립보드 복사 처리
+        viewModel.state.copySuccess
             .subscribe(onNext: { code in
                 UIPasteboard.general.string = code
             })
             .disposed(by: disposeBag)
-
 
         viewModel.state.showMessage
             .observe(on: MainScheduler.instance)
@@ -174,7 +174,6 @@ final class SendInviteViewController: UIViewController{
                 toastView.show(in: self.view, message: message, type: type)
             })
             .disposed(by: disposeBag)
-
 
         copyButton.rx.tap
             .map{SendInviteViewModel.Action.copyButtonTapped }

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/SendInviteViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewController/SendInviteViewController.swift
@@ -154,17 +154,44 @@ final class SendInviteViewController: UIViewController{
 
     // MARK: - Bind
     private func bindViewModel() {
+        // 데이터 바인딩
+        bindInviteCode()
+        bindCopyAction()
+        bindCopySuccess()
+        bindNavigation()
+        bindMessages()
+    }
+
+    private func bindInviteCode() {
         viewModel.state.inviteCode
             .bind(to: inviteCodeLabel.rx.text)
             .disposed(by: disposeBag)
+    }
 
+    private func bindCopyAction() {
+        copyButton.rx.tap
+            .map{SendInviteViewModel.Action.copyButtonTapped }
+            .bind(to: viewModel.action)
+            .disposed(by: disposeBag)
+    }
+
+    private func bindCopySuccess() {
         // 복사 성공 시그널을 구독하여 실제 클립보드 복사 처리
         viewModel.state.copySuccess
             .subscribe(onNext: { code in
                 UIPasteboard.general.string = code
             })
             .disposed(by: disposeBag)
+    }
 
+    private func bindNavigation() {
+        navigationBar.backTapped
+            .bind(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }.disposed(by: disposeBag)
+    }
+
+    private func bindMessages() {
         viewModel.state.showMessage
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] (type, message) in
@@ -174,20 +201,26 @@ final class SendInviteViewController: UIViewController{
                 toastView.show(in: self.view, message: message, type: type)
             })
             .disposed(by: disposeBag)
-
-        copyButton.rx.tap
-            .map{SendInviteViewModel.Action.copyButtonTapped }
-            .bind(to: viewModel.action)
-            .disposed(by: disposeBag)
-
-        navigationBar.backTapped
-            .bind(with: self) { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
-
     }
 
+    // MARK: - Error Handling
+    private func handleError(_ error: Error) {
+        let message = error.localizedDescription
+        viewModel.state.showMessage.accept((.failure, message))
+    }
+    
+    // MARK: - Utility Methods
+    private func handleCopyInviteCode() {
+        // 복사 관련 추가 로직이 필요한 경우
+        print("Copy invite code handled")
+    }
+
+    private func processCopyRequest() {
+        // 복사 요청 처리 로직이 필요한 경우
+        print("Copy request processed")
+    }
 }
+
     // MARK: - UINavigationControllerDelegate
 
 extension SendInviteViewController: UIGestureRecognizerDelegate {

--- a/StampIt-Project/StampIt-Project/Presentation/Invite/ViewModel/SendInviteViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Invite/ViewModel/SendInviteViewModel.swift
@@ -19,8 +19,7 @@ final class SendInviteViewModel: ViewModelProtocol {
     struct State {
         let inviteCode = BehaviorRelay<String>(value: "")
         let showMessage = PublishRelay<(ToastType, String)>()
-        let copyToClipboard = PublishRelay<String>()
-
+        let copySuccess = PublishRelay<String>()
     }
 
     // MARK: - Properties
@@ -56,7 +55,8 @@ final class SendInviteViewModel: ViewModelProtocol {
         useCase.getInviteCode()
             .subscribe(onNext: { [weak self] code in
                 guard let self = self else { return }
-                self.state.copyToClipboard.accept(code)
+                // 복사 성공 시 데이터 스트림 viewController로 전달
+                self.state.copySuccess.accept(code)
                 self.state.showMessage.accept((.success, "초대 코드가 복사되었습니다"))
             }, onError: { [weak self] error in
                 let message: String


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-175

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
초대하기 화면 입장식 초대코드가 자동으로 복사되던 이슈 수정
초대받기 화면에서 키보드 관련 로직 추가
 - 키보드가 보일 때 다른 화면 탭시 키보드 내려가게 설정
 - 키보드가 초대 코드를 입력해야하는 텍스트 필드를 가리는 경우
 키보드 오프셋 설정
바인딩 메서드 코드 정리

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "" width ="250">|


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
왠만하면 모든 기기에서 테스트를 해봤는데요 이상하게 기기가 작은 화면에서는 원하는 만큼의 세팅값이 적용이 안되는 느낌이 들었습니다.