### PR TITLE
[Feat] STAMPIT-178 커스텀 미션 전달하기 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -67,6 +67,8 @@ final class MissionRepositoryImpl: MissionRepository {
                 return "health"
             case .learning:
                 return "learning"
+            case .custom:
+                return "custom"
             }
         }()
         

--- a/StampIt-Project/StampIt-Project/Domain/Entities/MissionCategory.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/MissionCategory.swift
@@ -12,4 +12,5 @@ enum MissionCategory: String, CaseIterable, Decodable {
     case communication
     case health
     case learning
+    case custom
 }

--- a/StampIt-Project/StampIt-Project/Domain/Entities/SampleMission.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/SampleMission.swift
@@ -38,4 +38,11 @@ struct SampleMission: Decodable {
             throw DecodingError.dataCorruptedError(forKey: .category, in: container, debugDescription: "Unknown category: \(categoryString)")
         }
     }
+    
+    init(missionId: String, title: String, description: String?, category: MissionCategory) {
+        self.missionId = missionId
+        self.title = title
+        self.description = description
+        self.category = category
+    }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Model/MissionCategory+Extension.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Model/MissionCategory+Extension.swift
@@ -18,6 +18,8 @@ extension MissionCategory {
             "건강운동"
         case .learning:
             "독서학습"
+        case .custom:
+            "사용자정의"
         }
     }
 
@@ -31,6 +33,8 @@ extension MissionCategory {
                 .health
         case .learning:
                 .learning
+        case .custom:
+                .mascotRed
         }
     }
 
@@ -44,6 +48,8 @@ extension MissionCategory {
                 .yellow100
         case .learning:
                 .purple100
+        case .custom:
+                .gray50
         }
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -15,8 +15,9 @@ import Then
 final class AssignMissionViewController: UIViewController {
     private let navigationBar = DefaultNavigationBar(.titleWithBackButton(title: "미션 전달하기"))
     
-    private let missionTitleLabel = UILabel().then {
+    private let missionTitleTextField = UITextField().then {
         $0.font = .pretendard(size: 18, weight: .bold)
+        $0.placeholder = "미션 제목을 입력하세요"
     }
     
     private let memberLabel = UILabel().then {
@@ -103,9 +104,10 @@ final class AssignMissionViewController: UIViewController {
         view.backgroundColor = .white
         
         // dropdownView는 보여질 때 일부 화면이 가려지므로(예: dueDateStackView) 마지막에 서브 뷰로 추가
-        [navigationBar, missionTitleLabel, memberStackView, dueDateView, assignButton, dropdownView].forEach {
-            view.addSubview($0)
-        }
+        [navigationBar, missionTitleTextField, memberStackView, dueDateView, assignButton, dropdownView]
+            .forEach {
+                view.addSubview($0)
+            }
         
         [memberLabel, memberSelectionButton].forEach {
             memberStackView.addArrangedSubview($0)
@@ -118,13 +120,13 @@ final class AssignMissionViewController: UIViewController {
             $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
         }
         
-        missionTitleLabel.snp.makeConstraints {
+        missionTitleTextField.snp.makeConstraints {
             $0.top.equalTo(navigationBar.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
         memberStackView.snp.makeConstraints {
-            $0.top.equalTo(missionTitleLabel.snp.bottom).offset(24)
+            $0.top.equalTo(missionTitleTextField.snp.bottom).offset(24)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
@@ -158,7 +160,16 @@ final class AssignMissionViewController: UIViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] mission in
                 guard let self, let mission else { return }
-                missionTitleLabel.text = mission.title
+                missionTitleTextField.text = mission.title
+            }
+            .disposed(by: disposeBag)
+        
+        // 미션 제목 수정 시
+        missionTitleTextField.rx.text
+            .orEmpty
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] text in
+                self?.viewModel.action.accept(.didFillOutTitle(text))
             }
             .disposed(by: disposeBag)
         
@@ -179,9 +190,16 @@ final class AssignMissionViewController: UIViewController {
                 guard let self, let member else { return }
                 
                 memberSelectionButton.configuration = configureButton(title: member.nickname, titleColor: .gray800) // 버튼에 선택한 멤버 이름 표시
-                assignButton.isEnabled = true // 미션 전달하기 버튼 활성화
                 dropdownView.isHidden = true
                 isDropdown = false
+            }
+            .disposed(by: disposeBag)
+        
+        // 전달하기 버튼 활성화 여부
+        viewModel.state.canSubmit
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] isEnabled in
+                self?.assignButton.isEnabled = isEnabled
             }
             .disposed(by: disposeBag)
         

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -16,6 +16,16 @@ final class MissionListViewController: UIViewController {
     
     private let navigationBar = DefaultNavigationBar(.plainTitle(title: "미션"))
     
+    private lazy var addButton = UIButton().then {
+        var configuration = UIButton.Configuration.filled()
+        configuration.baseBackgroundColor = .gray50
+        configuration.baseForegroundColor = .red400
+        configuration.cornerStyle = .capsule
+        configuration.image = UIImage(systemName: "plus")
+        $0.configuration = configuration
+        $0.addTarget(self, action: #selector(addCustomMission), for: .touchUpInside)
+    }
+    
     private let searchBar = UISearchBar().then {
         $0.searchBarStyle = .minimal
         $0.placeholder = "검색어를 입력해주세요"
@@ -84,6 +94,8 @@ final class MissionListViewController: UIViewController {
     private func prepareSubviews() {
         view.backgroundColor = .white
         
+        navigationBar.addSubview(addButton)
+        
         [navigationBar, searchBar, collectionView, tableView].forEach {
             view.addSubview($0)
         }
@@ -93,6 +105,11 @@ final class MissionListViewController: UIViewController {
         navigationBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-16)
         }
         
         searchBar.snp.makeConstraints {
@@ -251,6 +268,17 @@ final class MissionListViewController: UIViewController {
         snapshot.appendItems(items)
         
         dataSource?.apply(snapshot, animatingDifferences: true)
+    }
+    
+    // 커스텀 미션 생성
+    @objc private func addCustomMission() {
+        let viewModel = AssignMissionViewModel(missionUseCaseImpl: DIContainer.shared.missionUseCase)
+        viewModel.onSuccess = { [weak self] in
+            guard let self else { return }
+            toastView.show(in: view, duration: 3, message: "미션이 전달되었어요", type: .success)
+        }
+        let viewController = AssignMissionViewController(viewModel: viewModel)
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -12,6 +12,7 @@ import RxRelay
 final class AssignMissionViewModel: ViewModelProtocol {
     enum Action {
         case onAppear
+        case didFillOutTitle(String)
         case didSelectMember(Member)
         case didSelectDueDate(Date)
         case didTapAssignButton
@@ -22,6 +23,8 @@ final class AssignMissionViewModel: ViewModelProtocol {
         var members = BehaviorRelay<[Member]>(value: [])
         var selectedMember = BehaviorRelay<Member?>(value: nil)
         var dueDate = BehaviorRelay<Date>(value: Date())
+        var canSubmit = BehaviorRelay<Bool>(value: false)
+        var customMissionTitle = BehaviorRelay<String?>(value: nil)
     }
     
     var action = PublishRelay<Action>()
@@ -31,16 +34,33 @@ final class AssignMissionViewModel: ViewModelProtocol {
     
     var onSuccess: (() -> Void)? // 새로운 미션이 생성되어 파이어베이스까지 저장 완료되었을 때 호출
     
-    private let mission: SampleMission
     private let missionUseCaseImpl: MissionUseCase
     private var user: User?
     
+    private var canSubmit: Bool {
+        // 멤버 선택이 안되어 있으면 false
+        if state.selectedMember.value == nil { return false }
+        
+        // 만약 커스텀 미션이 아니라면(샘플 미션이라면) 멤버 선택은 이미 되어 있으므로 true
+        if let mission = state.mission.value, !mission.title.isEmpty { return true }
+        
+        // 만약 커스텀 미션이고, 미션 제목을 입력했다면 true
+        if let title = state.customMissionTitle.value, !title.isEmpty { return true }
+        
+        return false
+    }
+    
     init(
-        mission: SampleMission,
+        mission: SampleMission? = nil,
         selectedMember: Member? = nil,
         missionUseCaseImpl: MissionUseCase
     ) {
-        self.mission = mission
+        if let mission {
+            state.mission.accept(mission)
+        } else {
+            let mission = SampleMission(missionId: "", title: "", description: nil, category: .chore)
+            state.mission.accept(mission)
+        }
         
         // 홈 화면에서 특정 멤버가 선택된 상태에서 미션 화면으로 진입할 때 사용
         if let selectedMember {
@@ -65,11 +85,14 @@ final class AssignMissionViewModel: ViewModelProtocol {
                 
                 switch input {
                 case .onAppear:
-                    state.mission.accept(mission)
                     loadMembers()
                     print("mission: \(String(describing: state.mission.value?.title)), members count: \(state.members.value.count)")
+                case .didFillOutTitle(let title):
+                    state.customMissionTitle.accept(title)
+                    state.canSubmit.accept(canSubmit)
                 case .didSelectMember(let member):
                     state.selectedMember.accept(member)
+                    state.canSubmit.accept(canSubmit)
                     print("selected member: \(member)")
                 case .didSelectDueDate(let date):
                     state.dueDate.accept(date)
@@ -131,16 +154,18 @@ final class AssignMissionViewModel: ViewModelProtocol {
             return Observable.error(NSError(domain: "user data is nil.", code: 0, userInfo: nil))
         }
         
+        let title = state.customMissionTitle.value ?? state.mission.value!.title
+        
         let mission = Mission(
             missionID: UUID().uuidString,
-            title: mission.title,
+            title: title,
             assignedTo: member.userID,
             assignedBy: user.userID,
             createDate: Date(),
             dueDate: dueDate,
             status: MissionStatus.assigned,
             imageURL: "",
-            category: mission.category)
+            category: state.mission.value!.category)
         
         return missionUseCaseImpl.createMission(groupId: user.groupID, mission: mission)
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -58,7 +58,7 @@ final class AssignMissionViewModel: ViewModelProtocol {
         if let mission {
             state.mission.accept(mission)
         } else {
-            let mission = SampleMission(missionId: "", title: "", description: nil, category: .chore)
+            let mission = SampleMission(missionId: "", title: "", description: nil, category: .custom)
             state.mission.accept(mission)
         }
         

--- a/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
+++ b/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
@@ -81,6 +81,8 @@ final class MissionRepositoryTest: MissionRepository {
                 return "health"
             case .learning:
                 return "learning"
+            case .custom:
+                return "custom"
             }
         }()
         
@@ -95,7 +97,7 @@ final class MissionRepositoryTest: MissionRepository {
             dueDate: Timestamp(date: mission.dueDate),
             category: category,
             status: MissionFirestore.Status.assigned.rawValue,
-            missionType: MissionFirestore.MissionType.app.rawValue,
+            missionType: MissionFirestore.MissionType.app.rawValue
         )
         return Observable.create { _ in
             print("""


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-178

## 📌 변경 사항 및 이유
- 커스텀 미션 생성 및 전달하기 구현

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-30 at 16 26 00](https://github.com/user-attachments/assets/3501334b-9709-4265-8655-2e0c7677d6c7)|

## 📌 PR Point
없음

## 📌 참고 사항
- 커스텀 미션 카테고리가 추가되었습니다(MissionCategory.custom). 혹시 맡으신 각 파트에서 카테고리 추가로 인해 문제 발생하시면 피드백 부탁드립니다.
- 기존처럼 미션 리스트 중 하나를 골라서 미션 전달할 때도, 미션 제목을 수정할 수 있도록 했습니다. 사용자에게 좀 더 자유도(?)를 주고자 했습니다. 반대의견 많으시면 수정 못하도록 막겠습니다.
- 전체 디자인은 아직 민경님의 손길이 닿지 않았습니다. 색상, 문구, 아이콘 등 수정이 발생할 예정입니다.