### PR TITLE
[Fix] STAMPIT-179 내 정보 수정 화면 UT 피드백 반영

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -17,7 +17,7 @@ final class AssignMissionViewController: UIViewController {
     
     private let missionTitleTextField = UITextField().then {
         $0.font = .pretendard(size: 18, weight: .bold)
-        $0.placeholder = "미션 제목을 입력하세요"
+        $0.placeholder = "미션 내용"
     }
     
     private let memberLabel = UILabel().then {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -18,9 +18,8 @@ final class MissionListViewController: UIViewController {
     
     private lazy var addButton = UIButton().then {
         var configuration = UIButton.Configuration.filled()
-        configuration.baseBackgroundColor = .gray50
+        configuration.baseBackgroundColor = .clear
         configuration.baseForegroundColor = .red400
-        configuration.cornerStyle = .capsule
         configuration.image = UIImage(systemName: "plus")
         $0.configuration = configuration
         $0.addTarget(self, action: #selector(addCustomMission), for: .touchUpInside)

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileTextField.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileTextField.swift
@@ -1,0 +1,32 @@
+//
+//  EditProfileTextField.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 6/30/25.
+//
+
+import UIKit
+
+final class EditProfileTextField: UITextField {
+    // 텍스트필드 왼쪽/오른쪽 여백
+    let textPadding = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
+    // 클리어 버튼 여백
+    let clearButtonPadding: CGFloat = 16
+    
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textPadding)
+    }
+    
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textPadding)
+    }
+    
+    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textPadding)
+    }
+    
+    override func clearButtonRect(forBounds bounds: CGRect) -> CGRect {
+        let original = super.clearButtonRect(forBounds: bounds)
+        return original.offsetBy(dx: -clearButtonPadding, dy: 0)
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -51,6 +51,11 @@ final class EditProfileViewController: UIViewController {
         $0.spacing = 4
     }
     
+    private let nicknameErrorLabel = UILabel().then {
+        $0.font = .pretendard(size: 12, weight: .regular)
+        $0.textColor = .red400
+    }
+    
     private let groupNameLabel = UILabel().then {
         $0.text = "그룹명"
         $0.font = .pretendard(size: 14, weight: .regular)
@@ -82,8 +87,6 @@ final class EditProfileViewController: UIViewController {
     }
     
     private let editButton = DefaultButton(type: .modify)
-    
-    private let toastView = ToastView()
     
     private let viewModel: EditProfileViewModel
     private let disposeBag = DisposeBag()
@@ -145,6 +148,7 @@ final class EditProfileViewController: UIViewController {
          profileImageLabel,
          collectionView,
          nicknameStackView,
+         nicknameErrorLabel,
          groupNameStackView,
          alertMessageLabel,
          editButton]
@@ -176,6 +180,11 @@ final class EditProfileViewController: UIViewController {
         nicknameTextField.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(72)
+        }
+        
+        nicknameErrorLabel.snp.makeConstraints {
+            $0.top.equalTo(nicknameStackView.snp.bottom).offset(4)
+            $0.leading.equalToSuperview().offset(24)
         }
         
         groupNameStackView.snp.makeConstraints {
@@ -239,7 +248,10 @@ final class EditProfileViewController: UIViewController {
             .distinctUntilChanged()
             .skip(1)
             .drive { [weak self] in
-                self?.viewModel.action.accept(.nicknameChanged($0))
+                guard let self else { return }
+                
+                nicknameErrorLabel.text = ""
+                viewModel.action.accept(.nicknameChanged($0))
             }
             .disposed(by: disposeBag)
         
@@ -248,8 +260,7 @@ final class EditProfileViewController: UIViewController {
             .asDriver(onErrorDriveWith: .empty())
             .skip(1)
             .drive { [weak self] message in
-                guard let self, let message else { return }
-                toastView.show(in: view, duration: 3, message: message, type: .failure)
+                self?.nicknameErrorLabel.text = message
             }
             .disposed(by: disposeBag)
         

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/EditProfileViewController.swift
@@ -33,7 +33,7 @@ final class EditProfileViewController: UIViewController {
         $0.textColor = .gray400
     }
     
-    private let nicknameTextField = UITextField().then {
+    private let nicknameTextField = EditProfileTextField().then {
         $0.font = .pretendard(size: 18, weight: .bold)
         $0.textColor = .gray300
         $0.layer.cornerRadius = 16
@@ -41,12 +41,7 @@ final class EditProfileViewController: UIViewController {
         $0.layer.borderColor = UIColor.gray200.cgColor
         $0.layer.borderWidth = 1
         $0.clearButtonMode = .whileEditing
-        
-        // placeholder 관련
         $0.placeholder = "닉네임"
-        let leftView = UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 0))
-        $0.leftView = leftView
-        $0.leftViewMode = .always
     }
     
     // nicknameLabel + nicknameTextField
@@ -62,7 +57,7 @@ final class EditProfileViewController: UIViewController {
         $0.textColor = .gray400
     }
     
-    private let groupNameTextField = UITextField().then {
+    private let groupNameTextField = EditProfileTextField().then {
         $0.font = .pretendard(size: 18, weight: .bold)
         $0.textColor = .gray300
         $0.layer.cornerRadius = 16
@@ -70,12 +65,7 @@ final class EditProfileViewController: UIViewController {
         $0.layer.borderColor = UIColor.gray200.cgColor
         $0.layer.borderWidth = 1
         $0.clearButtonMode = .whileEditing
-        
-        // placeholder 관련
         $0.placeholder = "그룹명"
-        let leftView = UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 0))
-        $0.leftView = leftView
-        $0.leftViewMode = .always
     }
     
     // groupNameLabel + groupNameTextField


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-179

## 📌 변경 사항 및 이유
- 텍스트필드 클리어버튼 우측 여백이 부족 -> 여백 더 확보
- 닉네임 수정 시 키보드 올라왔을 때 토스트 메시지 가려짐 -> 토스트 대신 텍스트필드 하단에 알림문구 추가

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro 클리어버튼 여백 |![Simulator Screen Recording - iPhone 16 Pro - 2025-06-30 at 20 13 36](https://github.com/user-attachments/assets/c55fc50a-62dc-4068-a044-f0d45c21ac4e)|
| iPhone 16 Pro 토스트 메시지 가려짐|![Simulator Screen Recording - iPhone 16 Pro - 2025-06-30 at 20 30 37](https://github.com/user-attachments/assets/b9a93b25-3f69-4769-91e0-f3833e5ce9e9)|

## 📌 PR Point
- 고객님의 소중한 의견 감사합니다!!

## 📌 참고 사항
- 텍스트필드 클래스에 leftView, rightView 프라퍼티가 있어서 이걸로 여백을 줄 수 있는데 클리어버튼에는 적용이 안되네요.