### PR TITLE
[Feat] STAMPIT-179 - 샘플미션 즐겨찾기 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -139,8 +139,15 @@ final class MissionListViewController: UIViewController {
         // 미션 샘플 데이터를 테이블 뷰에 표시
         viewModel.state.missions
             .asDriver(onErrorDriveWith: .empty())
-            .drive(tableView.rx.items(cellIdentifier: MissionListCell.reuseIdentifier, cellType: MissionListCell.self)) { (_, element, cell) in
-                cell.configure(with: element.title)
+            .drive(tableView.rx.items(cellIdentifier: MissionListCell.reuseIdentifier, cellType: MissionListCell.self)) { [weak self] (_, element, cell) in
+                guard let self else { return }
+                
+                let favorites = viewModel.state.favorites.value
+                if favorites.contains(element.missionId) {
+                    cell.configure(with: element.title, isFavorite: true)
+                } else {
+                    cell.configure(with: element.title, isFavorite: false)
+                }
             }
             .disposed(by: disposeBag)
         
@@ -289,6 +296,16 @@ extension MissionListViewController: UITableViewDelegate {
             return 0
         }
         return 16
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let favoriteAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completion in
+            self?.viewModel.action.accept(.toggleFavorite(indexPath))
+            completion(true)
+        }
+        favoriteAction.image = UIImage(systemName: "star")
+        favoriteAction.backgroundColor = .gray200
+        return UISwipeActionsConfiguration(actions: [favoriteAction])
     }
 }
 

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
@@ -18,10 +18,15 @@ final class MissionListCell: UITableViewCell {
         $0.numberOfLines = 0
     }
     
+    private let favoriteImageView = UIImageView().then {
+        $0.image = UIImage(systemName: "star.fill")
+        $0.tintColor = .red200
+    }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        contentView.addSubview(label)
+        [label, favoriteImageView].forEach { addSubview($0) }
         
         setConstraints()
         
@@ -35,13 +40,25 @@ final class MissionListCell: UITableViewCell {
     private func setConstraints() {
         label.snp.makeConstraints {
             $0.verticalEdges.equalToSuperview().inset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalTo(favoriteImageView).inset(8)
+        }
+        
+        favoriteImageView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
         }
     }
     
     /// 테이블 뷰 셀 업데이트
     /// - Parameter text: 미션 타이틀(예: 방 청소하기)
-    func configure(with text: String) {
+    func configure(with text: String, isFavorite: Bool) {
         label.text = text
+        
+        if isFavorite {
+            favoriteImageView.isHidden = false
+        } else {
+            favoriteImageView.isHidden = true
+        }
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -15,12 +15,14 @@ final class MissionListViewModel: ViewModelProtocol {
         case searchTextChanged(String)
         case didSelectTableViewCell(SampleMission)
         case didSelectCollectionViewCell(IndexPath)
+        case toggleFavorite(IndexPath)
     }
     
     struct State {
         var missions = BehaviorRelay<[SampleMission]>(value: []) // 뷰에 반영되는 샘플 미션 데이터
         var searchText = BehaviorRelay<String>(value: "")
         var selectedCategory = BehaviorRelay<MissionCategory?>(value: nil)
+        var favorites = BehaviorRelay<Set<String>>(value: [])
     }
     
     var action = PublishRelay<Action>()
@@ -37,6 +39,8 @@ final class MissionListViewModel: ViewModelProtocol {
         bind()
         
         bindFilterMisson()
+        
+        loadFavorites()
     }
     
     private func bind() {
@@ -50,7 +54,7 @@ final class MissionListViewModel: ViewModelProtocol {
                         .subscribe { [weak self] missions in
                             guard let self else { return }
                             
-                            let sortedMissions = missions.sorted { $0.title < $1.title }
+                            let sortedMissions = sort(missions)
                             state.missions.accept(sortedMissions)
                             _missions = sortedMissions
                         } onFailure: { error in
@@ -71,6 +75,18 @@ final class MissionListViewModel: ViewModelProtocol {
                         state.selectedCategory.accept(category)
                         print("category: \(category.title)")
                     }
+                case .toggleFavorite(let indexPath):
+                    let mission = state.missions.value[indexPath.row]
+                    var favorites = state.favorites.value
+                    
+                    // 토글 형식이므로, 현재 즐겨찾기인 미션을 탭하면 즐겨찾기 해제, 현재 즐겨찾기가 아닌 미션을 탭하면 즐겨찾기 등록
+                    if favorites.contains(mission.missionId) {
+                        favorites.remove(mission.missionId)
+                    } else {
+                        favorites.insert(mission.missionId)
+                    }
+                    state.favorites.accept(favorites)
+                    UserDefaults.standard.set(Array(favorites), forKey: "favorites")
                 }
             }
             .disposed(by: disposeBag)
@@ -78,8 +94,8 @@ final class MissionListViewModel: ViewModelProtocol {
     
     // 미션 검색 + 카테고리 선택
     private func bindFilterMisson() {
-        Observable.combineLatest(state.searchText, state.selectedCategory)
-            .map { [weak self] searchText, selectedCategory -> [SampleMission] in
+        Observable.combineLatest(state.searchText, state.selectedCategory, state.favorites)
+            .map { [weak self] searchText, selectedCategory, _ -> [SampleMission] in
                 guard let self else { return [] }
                 
                 // 단어 단위로 분할
@@ -88,7 +104,7 @@ final class MissionListViewModel: ViewModelProtocol {
                     .components(separatedBy: .whitespaces)
                     .filter { !$0.isEmpty }
                 
-                return _missions.filter { mission in
+                let filteredMissions = _missions.filter { mission in
                     // 카테고리 필터
                     if let category = selectedCategory, mission.category != category {
                         return false
@@ -105,8 +121,35 @@ final class MissionListViewModel: ViewModelProtocol {
                         title.localizedStandardContains(keyword)
                     }
                 }
+                
+                return sort(filteredMissions)
             }
             .bind(to: state.missions)
             .disposed(by: disposeBag)
+    }
+    
+    // 정렬 우선순위: 1순위 즐겨찾기 여부 -> 2순위 미션 타이틀명
+    private func sort(_ missions: [SampleMission]) -> [SampleMission] {
+        // 우선 전체 데이터를 타이틀명 기준으로 정렬
+        let missions = missions.sorted { $0.title < $1.title }
+        
+        let favorites = state.favorites.value
+        
+        let favoriteMissions = missions.filter {
+            favorites.contains($0.missionId)
+        }
+        
+        let noFavoriteMissions = missions.filter {
+            !favorites.contains($0.missionId)
+        }
+        
+        // 즐겨찾기 등록된 미션을 앞으로, 나머지는 뒤로
+        return favoriteMissions + noFavoriteMissions
+    }
+    
+    // 즐겨찾기 샘플미션 로드
+    private func loadFavorites() {
+        let favorites = UserDefaults.standard.stringArray(forKey: "favorites") ?? []
+        state.favorites.accept(Set(favorites))
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-179

## 📌 변경 사항 및 이유
- 우선 한번 보여드리고 피드백 받으려고 PR 했습니다(approve 안하셔도 됩니다)
- 즐겨찾기 정보는 user defaults에 저장합니다.
- 즐겨찾기 true를 최상단에 보여주되, 해당 카테고리와 검색어가 모두 해당될 경우에만 노출됩니다.

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![Simulator Screen Recording - iPhone 16 Pro - 2025-07-01 at 17 24 08](https://github.com/user-attachments/assets/8f119a19-ef28-4154-8f12-e562733f54c5)|

## 📌 PR Point
없음

## 📌 참고 사항
없음