### PR TITLE
[Feat] STAMPIT-181 - VersionCheck 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -13,26 +13,55 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = (scene as? UIWindowScene) else { return }
         
+        // 1. VersionCheckViewModel 인스턴스 준비
+        let versionCheckViewModel = VersionCheckViewModel()
+        
+        guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let hasOnboarded = UserDefaults.standard.bool(forKey: "hasOnboarded")
-        let container = DIContainer.shared
-        let nav: UINavigationController
-        
-        if hasOnboarded {
-            // 온보딩 끝났으면 → LaunchViewController(분기 전용)로 이동
-            let launchVC = LaunchViewController(container: container)
-            nav = UINavigationController(rootViewController: launchVC)
-        } else {
-            // 온보딩 필요 → 온보딩 화면
-            let onboardingVC = DIContainer.shared.makeOnboardingViewController()
-            nav = UINavigationController(rootViewController: onboardingVC)
+        // 2. 버전 체크 먼저
+        versionCheckViewModel.checkForceUpdate { [weak self] needUpdate, message in
+            guard let self else { return }
+            if needUpdate {
+                // 3. 강제 업데이트 알럿만 띄우기 (이전 버전은 앱 사용 불가)
+                let alert = UIAlertController(
+                    title: "업데이트 필요",
+                    message: message ?? "최신 버전으로 업데이트 해주세요!",
+                    preferredStyle: .alert
+                )
+                let updateAction = UIAlertAction(title: "업데이트 하러가기", style: .default) { _ in
+                    if let url = URL(string: "itms-apps://itunes.apple.com/app/id6747178558") {
+                        DispatchQueue.main.async {
+                            UIApplication.shared.open(url, options: [:], completionHandler: { success in
+                                if !success {
+                                    print("잠시 후 다시 시도해주세요.")
+                                }
+                            })
+                        }
+                    }
+                }
+                alert.addAction(updateAction)
+                self.window?.rootViewController = UIViewController()
+                self.window?.makeKeyAndVisible()
+                self.window?.rootViewController?.present(alert, animated: true)
+                return
+            }
+            
+            // 4. 정상 분기 (온보딩/런치/메인 등 기존 로직)
+            let hasOnboarded = UserDefaults.standard.bool(forKey: "hasOnboarded")
+            let container = DIContainer.shared
+            let nav: UINavigationController
+            if hasOnboarded {
+                let launchVC = LaunchViewController(container: container)
+                nav = UINavigationController(rootViewController: launchVC)
+            } else {
+                let onboardingVC = container.makeOnboardingViewController()
+                nav = UINavigationController(rootViewController: onboardingVC)
+            }
+            self.window?.rootViewController = nav
+            self.window?.makeKeyAndVisible()
         }
-        window?.rootViewController = nav
-        
-        window?.makeKeyAndVisible()
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -65,7 +94,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
-    
-    
 }
 

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -31,14 +31,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     preferredStyle: .alert
                 )
                 let updateAction = UIAlertAction(title: "업데이트 하러가기", style: .default) { _ in
-                    if let url = URL(string: "itms-apps://itunes.apple.com/app/id6747178558") {
-                        DispatchQueue.main.async {
-                            UIApplication.shared.open(url, options: [:], completionHandler: { success in
-                                if !success {
-                                    print("잠시 후 다시 시도해주세요.")
-                                }
-                            })
-                        }
+                    guard let url = URL(string: "itms-apps://itunes.apple.com/app/id6747178558") else { return }
+                    DispatchQueue.main.async {
+                        UIApplication.shared.open(url, options: [:], completionHandler: { success in
+                            if !success {
+                                print("잠시 후 다시 시도해주세요.")
+                            }
+                        })
                     }
                 }
                 alert.addAction(updateAction)

--- a/StampIt-Project/StampIt-Project/Domain/Service/VersionCheckService.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Service/VersionCheckService.swift
@@ -1,0 +1,20 @@
+//
+//  VersionCheckService.swift
+//  StampIt-Project
+//
+//  Created by iOS study on 7/1/25.
+//
+
+import FirebaseFirestore
+
+final class VersionCheckService {
+    func fetchLatestVersion(completion: @escaping (String?, String?) -> Void) {
+        let db = Firestore.firestore()
+        db.collection("config").document("appConfig").getDocument { snapshot, error in
+            let data = snapshot?.data()
+            let version = data?["latestVersion"] as? String
+            let message = data?["forceUpdateMessage"] as? String
+            completion(version, message)
+        }
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/VersionCheck/VM/VersionCheckViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/VersionCheck/VM/VersionCheckViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  VersionCheckViewModel.swift
+//  StampIt-Project
+//
+//  Created by iOS study on 7/1/25.
+//
+
+import Foundation
+
+final class VersionCheckViewModel {
+    private let service = VersionCheckService()
+
+    func checkForceUpdate(completion: @escaping (Bool, String?) -> Void) {
+        service.fetchLatestVersion { latestVersion, message in
+            guard let latest = latestVersion,
+                  let current = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+                completion(false, nil)
+                return
+            }
+            let needUpdate = current.compare(latest, options: .numeric) == .orderedAscending
+            completion(needUpdate, message)
+        }
+    }
+}


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-181

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 1.1.3보다 작은 버전인 경우 앱스토어로 이동할 수 있도록 구현(버전 업데이트를 하지 않으면 앱 이용 불가)
2. DB에 config 컬렉션 구현(버전정보와 출력 텍스트를 필드로 지정해둠)
3. 테스트 플라이트는 배포 버전보다 숫자를 올려야 해서 머지한 이후에 버전 업데이트하고 테스트 플라이트 적용하겠습니다
4. 현재 시뮬레이터에서는 바로 앱스토어 이동하지 않습니다. 테스트 플라이트에서 앱스토어 이동되는지 확인해주시면 될 것 같습니다.
5. 버전 1.1.3으로 같이 변경 전입니다.(빌드 1.1.3으로 테스트도 해봤는데 1.1.3과 같거나 버전이 큰 경우 분기 흐름 정상 작동합니다)

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/622a8ef5-71f8-45be-a57c-5d9310020851" width ="250">|

