### PR TITLE
[Fix] STAMPIT-190 missionId 로 Sticker 모델에 넣어주도록 변경

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/Entities/Model/StickerFirestore.swift
+++ b/StampIt-Project/StampIt-Project/Data/Entities/Model/StickerFirestore.swift
@@ -31,13 +31,13 @@ extension StickerFirestore {
         return Sticker(
             userID: self.userId,
             stickerID: self.stickerId,
-            title: self.missionId,
-            description: self.missionId,
-            imageURL: "",
+            groupId: self.groupId,
+            month: self.month,
             type: StickerType(rawValue: self.type) ?? .stampRed,
-            createdAt: self.createdAt.dateValue(),
-            maxStickers: self.maxStickers,
             pinNumber: self.pinNumber,
+            createdAt: self.createdAt.dateValue(),
+            missionId: self.missionId,
+            maxStickers: self.maxStickers,
             assignedBy: self.assignedBy
         )
         

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/HomeRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/HomeRepositoryImpl.swift
@@ -87,6 +87,7 @@ final class HomeRepository: HomeRepositoryProtocol {
         missionTitle: String,
         maxSticker: Int,
         stickerType: String,
+        missionId: String,
         assignedBy: String
     ) -> Observable<Void> {
         stickerManager.createStickerFromMission(
@@ -95,7 +96,7 @@ final class HomeRepository: HomeRepositoryProtocol {
             missionTitle: missionTitle,
             maxStickers: maxSticker,
             stickerType: stickerType,
-            missionId: UUID().uuidString,
+            missionId: missionId,
             assignedBy: assignedBy
         )
     }

--- a/StampIt-Project/StampIt-Project/Domain/Entities/Sticker.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/Sticker.swift
@@ -10,13 +10,13 @@ import Foundation
 struct Sticker: Hashable {
     let userID: String
     let stickerID: String
-    let title: String
-    let description: String
-    let imageURL: String
+    let groupId: String
+    let month: String
     let type: StickerType
-    let createdAt: Date
-    let maxStickers: Int
     let pinNumber: Int
+    let createdAt: Date
+    let missionId: String
+    let maxStickers: Int
     let assignedBy: String
 }
 

--- a/StampIt-Project/StampIt-Project/Domain/Repository/HomeRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/HomeRepository.swift
@@ -31,6 +31,7 @@ protocol HomeRepositoryProtocol {
         missionTitle: String,
         maxSticker: Int,
         stickerType: String,
+        missionId: String,
         assignedBy: String
     ) -> Observable<Void>
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MyMissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MyMissionUseCaseImpl.swift
@@ -47,6 +47,7 @@ final class MyMissionUseCaseImpl: MyMissionUseCaseProtocol {
             missionTitle: mission.title,
             maxSticker: 30, // TODO: pin 번호 계산용
             stickerType: StickerType.stampRed.rawValue, // TODO: 스티커 타입 결정 로직 추가
+            missionId: mission.missionID,
             assignedBy: mission.assignedBy
         )
     }


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - STAMPIT-190

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- Sticker Data Model 과 일치하지 않는 Sticker Domain Entity 일치화
- 기존에 UUID 로 새로 생성됐던 missionId 를 받은 미션의 missionId 로 Sticker 모델에 넣어주도록 변경
