### PR TITLE
[Refactor] STAMPIT-191 - Repository Protocol 추상화 수정

### DIFF
--- a/StampIt-Project/StampIt-Project/App/DIContainer.swift
+++ b/StampIt-Project/StampIt-Project/App/DIContainer.swift
@@ -11,12 +11,12 @@ import UIKit
 final class DIContainer {
 
     // MARK: - Managers (Infrastructure Layer)
-    lazy var authManager: AuthManagerProtocol = AuthManager()
-    lazy var userManager: UserManager = UserManager()
-    lazy var groupManager: GroupManager = GroupManager()
-    lazy var membershipManager: MembershipManager = MembershipManager()
-    lazy var missionManager: MissionManager = MissionManager()
-    lazy var stickerManager: StickerManager = StickerManager()
+    lazy var authManager: any AuthManagerProtocol = AuthManager()
+    lazy var userManager: any UserManagerProtocol = UserManager()
+    lazy var groupManager: any GroupManagerProtocol = GroupManager()
+    lazy var membershipManager: any MembershipManagerProtocol = MembershipManager()
+    lazy var missionManager: any MissionManagerProtocol = MissionManager()
+    lazy var stickerManager: any StickerManagerProtocol = StickerManager()
 
 
     // MARK: - Repositories (Data Layer)
@@ -83,7 +83,7 @@ final class DIContainer {
             membershipManager: membershipManager,
             missionManager: missionManager,
             stickerManager: stickerManager,
-            authRepository: authRepository as! AuthRepository,
+            authRepository: authRepository,
             mapToRepositoryError: { error in
                 return RepositoryError.unknownError
             }

--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Membership/MembershipProtocol.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Membership/MembershipProtocol.swift
@@ -20,6 +20,9 @@ protocol MembershipManagerProtocol: FullCRUDRepository where Entity == GroupMemb
     func updateMemberLeaderStatus(groupId: String, userId: String, isLeader: Bool) -> Observable<Void>
     func fetchOldestMember(groupId: String, excludeUserId: String) -> Observable<GroupMembershipFirestore>
     func fetchGroupMemberCount(groupId: String) -> Observable<Int>
+    func updateMemberProfileImage(groupId: String, userId: String, profileImage: String) -> Observable<Void>
+    func deleteGroupMemberships(groupId: String) -> Observable<Void>
+    func updateMemberNickname(groupId: String, userId: String, nickname: String) -> Observable<Void>
     
     // TODO: 그룹 변경 관련 (기존 switchUserGroup 분해) > 리팩토링 후 Repo로 이동시켜야함
     func switchUserGroup(

--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Sticker/StickerProtocol.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Sticker/StickerProtocol.swift
@@ -21,6 +21,8 @@ protocol StickerManagerProtocol: FullCRUDRepository where Entity == StickerFires
     func fetchGroupStickers(groupId: String, month: String) -> Observable<[StickerFirestore]>
     func fetchAllUserStickers(userId: String) -> Observable<[StickerFirestore]>
     
+    func observeStickerCount(userId: String) -> Observable<Int>
+    
     // 삭제 메서드들 (기존 FirestoreManager 메서드)
     func deleteUserStickers(userId: String, groupId: String) -> Observable<Void>
     func deleteUserStickers(userId: String) -> Observable<Void>

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
@@ -13,12 +13,12 @@ import FirebaseAuth
 
 final class AccountManageRepository: AccountManageRepositoryProtocol {
 
-    private let authManager: AuthManagerProtocol
-    private let userManager: UserManager
-    private let groupManager: GroupManager
-    private let membershipManager: MembershipManager
-    private let missionManager: MissionManager
-    private let stickerManager: StickerManager
+    private let authManager: any AuthManagerProtocol
+    private let userManager: any UserManagerProtocol
+    private let groupManager: any GroupManagerProtocol
+    private let membershipManager: any MembershipManagerProtocol
+    private let missionManager: any MissionManagerProtocol
+    private let stickerManager: any StickerManagerProtocol
 
     private let authRepository: AuthRepositoryProtocol
 
@@ -27,13 +27,13 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
 
     // 의존성 주입
     init(
-        authManager: AuthManagerProtocol,
-        userManager: UserManager,
-        groupManager: GroupManager,
-        membershipManager: MembershipManager,
-        missionManager: MissionManager,
-        stickerManager: StickerManager,
-        authRepository: AuthRepository,
+        authManager: any AuthManagerProtocol,
+        userManager: any UserManagerProtocol,
+        groupManager: any GroupManagerProtocol,
+        membershipManager: any MembershipManagerProtocol,
+        missionManager: any MissionManagerProtocol,
+        stickerManager: any StickerManagerProtocol,
+        authRepository: any AuthRepositoryProtocol,
         mapToRepositoryError: @escaping (Error) -> RepositoryError
     ) {
         self.authManager = authManager

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AuthRepositoryImpl.swift
@@ -16,22 +16,22 @@ final class AuthRepository: AuthRepositoryProtocol {
     private let authManager: AuthManagerProtocol
     
     // 각 매니저별로 분리된 의존성 (새로운 매니저 구조)
-    private let userManager: UserManager
-    private let groupManager: GroupManager
-    private let membershipManager: MembershipManager
-    private let missionManager: MissionManager
-    private let stickerManager: StickerManager
+    private let userManager: any UserManagerProtocol
+    private let groupManager: any GroupManagerProtocol
+    private let membershipManager: any MembershipManagerProtocol
+    private let missionManager: any MissionManagerProtocol
+    private let stickerManager: any StickerManagerProtocol
     
     private let disposeBag = DisposeBag()
     
     // MARK: - Init
     init(
         authManager: AuthManagerProtocol,
-        userManager: UserManager,
-        groupManager: GroupManager,
-        membershipManager: MembershipManager,
-        missionManager: MissionManager,
-        stickerManager: StickerManager
+        userManager: any UserManagerProtocol,
+        groupManager: any GroupManagerProtocol,
+        membershipManager: any MembershipManagerProtocol,
+        missionManager: any MissionManagerProtocol,
+        stickerManager: any StickerManagerProtocol
     ) {
         self.authManager = authManager
         self.userManager = userManager
@@ -230,17 +230,6 @@ final class AuthRepository: AuthRepositoryProtocol {
     }
     
     func addMember(groupId: String, member: GroupMembershipFirestore) -> Observable<Void> {
-        //        // member 컬렉션 삭제, membership 컬렉션 사용
-        //        let membership = GroupMembershipFirestore(
-        //            membershipId: "\(groupId)_\(member.userId)",
-        //            groupId: groupId,
-        //            userId: member.userId,
-        //            nickname: member.nickname,
-        //            profileImage: member.profileImage,
-        //            isLeader: member.isLeader,
-        //            joinedAt: member.joinedAt
-        //        )
-        //        return membershipManager.create(membership)
         return membershipManager.create(member)
     }
     

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/EditProfileRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/EditProfileRepositoryImpl.swift
@@ -9,14 +9,14 @@ import Foundation
 import RxSwift
 
 final class EditProfileRepositoryImpl: EditProfileRepository {
-    private let userManager: UserManager
-    private let groupManager: GroupManager
-    private let membershipManager: MembershipManager
+    private let userManager: any UserManagerProtocol
+    private let groupManager: any GroupManagerProtocol
+    private let membershipManager: any MembershipManagerProtocol
     
     init(
-            userManager: UserManager,
-            groupManager: GroupManager,
-            membershipManager: MembershipManager
+            userManager: any UserManagerProtocol,
+            groupManager: any GroupManagerProtocol,
+            membershipManager: any MembershipManagerProtocol
         ) {
             self.userManager = userManager
             self.groupManager = groupManager

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/GroupManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/GroupManageRepositoryImpl.swift
@@ -11,11 +11,11 @@ import FirebaseFirestore
 
 final class GroupManageRepositoryImpl: GroupManageRepository {
     
-    private let groupManager: GroupManager
-    private let userManager: UserManager
-    private let membershipManager: MembershipManager
+    private let groupManager: any GroupManagerProtocol
+    private let userManager: any UserManagerProtocol
+    private let membershipManager: any MembershipManagerProtocol
     
-    init(groupManager: GroupManager, userManager: UserManager, membershipManager: MembershipManager) {
+    init(groupManager: any GroupManagerProtocol, userManager: any UserManagerProtocol, membershipManager: any MembershipManagerProtocol) {
         self.groupManager = groupManager
         self.userManager = userManager
         self.membershipManager = membershipManager

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/HomeRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/HomeRepositoryImpl.swift
@@ -10,14 +10,14 @@ import RxSwift
 import FirebaseFirestore
 
 final class HomeRepository: HomeRepositoryProtocol {
-    private let membershipManager: MembershipManager
-        private let stickerManager: StickerManager
-        private let missionManager: MissionManager
+    private let membershipManager: any MembershipManagerProtocol
+        private let stickerManager: any StickerManagerProtocol
+        private let missionManager: any MissionManagerProtocol
 
         init(
-            membershipManager: MembershipManager,
-            stickerManager: StickerManager,
-            missionManager: MissionManager
+            membershipManager: any MembershipManagerProtocol,
+            stickerManager: any StickerManagerProtocol,
+            missionManager: any MissionManagerProtocol
         ) {
             self.membershipManager = membershipManager
             self.stickerManager = stickerManager

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/InviteRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/InviteRepositoryImpl.swift
@@ -9,14 +9,14 @@ import Foundation
 import RxSwift
 
 final class InviteRepositoryImpl: InviteRepository {
-    private let groupManager: GroupManager
-    private let membershipManager: MembershipManager
-    private let userManager: UserManager
+    private let groupManager: any GroupManagerProtocol
+    private let membershipManager: any MembershipManagerProtocol
+    private let userManager: any UserManagerProtocol
     
     init(
-        groupManager: GroupManager,
-        membershipManager: MembershipManager,
-        userManager: UserManager
+        groupManager: any GroupManagerProtocol,
+        membershipManager: any MembershipManagerProtocol,
+        userManager: any UserManagerProtocol
     ) {
         self.groupManager = groupManager
         self.membershipManager = membershipManager

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -10,14 +10,14 @@ import RxSwift
 import FirebaseCore
 
 final class MissionRepositoryImpl: MissionRepository {
-    private let missionManager: MissionManager
-    private let membershipManager: MembershipManager
-    private let authRepository: AuthRepositoryProtocol
+    private let missionManager: any MissionManagerProtocol
+    private let membershipManager: any MembershipManagerProtocol
+    private let authRepository: any AuthRepositoryProtocol
     
     init(
-        missionManager: MissionManager,
-        membershipManager: MembershipManager,
-        authRepository: AuthRepositoryProtocol
+        missionManager: any MissionManagerProtocol,
+        membershipManager: any MembershipManagerProtocol,
+        authRepository: any AuthRepositoryProtocol
     ) {
         self.missionManager = missionManager
         self.membershipManager = membershipManager

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MyPageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MyPageRepositoryImpl.swift
@@ -9,9 +9,9 @@ import Foundation
 import RxSwift
 
 final class MyPageRepositoryImpl: MyPageRepository {
-    private let stickerManager: StickerManager
+    private let stickerManager: any StickerManagerProtocol
     
-    init(stickerManager: StickerManager) {
+    init(stickerManager: any StickerManagerProtocol) {
         self.stickerManager = stickerManager
     }
     


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-191

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. deleteGroupMemberships 함수 선언을 MembershipManagerProtocol에 추가
2.  구현체(MembershipManager)는 변경 없음
3. 프로토콜 기반 DI 안정성 향상

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
구체화 기반으로 작동되던 Repo들 모두 추상화로 Protocol 기반으로 사용하도록 수정했습니다.
Swift 5.6+에서는 모든 프로토콜 타입 변수/파라미터/리턴에 any 붙이기가 표준이라고 해서 any 붙여서 사용했습니다.
그리고 일부 프로토콜은 protocol을 붙이고 일부는 repository라고 붙이는데 이 부분 통일해야할 것 같습니다.(저랑 다은님은 protocol 붙였고, 나머지분들은 프로토콜명을 repository, usecase로 작성해주셨습니다)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
Swift 5.6+ 에서 표준으로 any를 붙여야 하는 이유를 설명해둔 참고자료
1. https://green1229.tistory.com/241
2. https://medium.com/@Lionable/%EC%8A%A4%EC%9C%84%ED%94%84%ED%8A%B8-existential-any-afb50eed02ce