### PR TITLE
[Fix] STAMPIT-189 - 그룹 탈퇴, 서비스 탈퇴 시 받은 미션만 삭제하도록 수정

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionManager.swift
@@ -310,7 +310,7 @@ final class MissionManager: MissionManagerProtocol {
         return delete(id: missionId)
     }
     
-    /// 특정 사용자 관련 미션 삭제 (유저 탈퇴 시 사용)
+    /// "특정 사용자" 관련 미션 삭제 (유저 탈퇴 시 사용)
     func deleteUserMissions(userId: String, groupId: String) -> Observable<Void> {
         // 사용자가 할당받은 미션과 할당한 미션을 모두 조회
         return Observable.zip(
@@ -340,7 +340,24 @@ final class MissionManager: MissionManagerProtocol {
         }
     }
     
-    /// 특정 그룹의 모든 미션 삭제 (그룹 삭제 시 사용)
+    // 특정 사용자가 "받은" 미션만 삭제 (그룹 탈퇴 시 사용)
+    func deleteReceivedMissions(userId: String, groupId: String) -> Observable<Void> {
+        return fetchList(query: .byAssignee(userId, groupId: groupId))
+            .flatMap { [weak self] missions -> Observable<Void> in
+                guard let self = self else {
+                    return Observable.error(MissionError.fetchFailed("MissionManager 인스턴스가 없습니다"))
+                }
+                guard !missions.isEmpty else {
+                    return Observable.just(())
+                }
+                let deleteObservables = missions.map { mission in
+                    self.delete(id: mission.documentID)
+                }
+                return Observable.zip(deleteObservables).map { _ in () }
+            }
+    }
+    
+    /// "특정 그룹"의 모든 미션 삭제 (그룹 삭제 시 사용)
     func deleteGroupMissions(groupId: String) -> Observable<Void> {
         return fetchList(query: .byGroup(groupId))
             .flatMap { [weak self] missions -> Observable<Void> in

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
@@ -191,7 +191,7 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
             membershipManager.removeMember(groupId: groupId, userId: userId),
             userManager.delete(id: userId),
             stickerManager.deleteUserStickers(userId: userId),
-            missionManager.deleteUserMissions(userId: userId, groupId: groupId)
+            missionManager.deleteReceivedMissions(userId: userId, groupId: groupId)
         )
         .map { _ in () }
         .catch { error in

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
@@ -537,13 +537,18 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
         currentGroupId: String,
         maxRetries: Int
     ) -> Observable<Void> {
-        return missionManager.deleteUserMissions(userId: userId, groupId: currentGroupId)
-            .retry(maxRetries)
-            .timeout(.seconds(5), scheduler: MainScheduler.instance)
-            .catch { error in
-                return Observable.error(GroupExitError.dataCleanupFailed(error.localizedDescription))
-            }
+        return Observable.zip(
+            missionManager.deleteUserMissions(userId: userId, groupId: currentGroupId),
+            stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)
+        )
+        .map { _ in () }
+        .retry(maxRetries)
+        .timeout(.seconds(5), scheduler: MainScheduler.instance)
+        .catch { error in
+            return Observable.error(GroupExitError.dataCleanupFailed(error.localizedDescription))
+        }
     }
+
 
     /// 롤백 시도 (베스트 에포트) (새로운 DB 구조 반영)
     private func attemptRollback(

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
@@ -538,8 +538,8 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
         maxRetries: Int
     ) -> Observable<Void> {
         return Observable.zip(
-            missionManager.deleteUserMissions(userId: userId, groupId: currentGroupId),
-            stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)
+            missionManager.deleteReceivedMissions(userId: userId, groupId: currentGroupId), // 받은 미션만 삭제
+            stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)      // 그룹과 관련된 본인 스티커 삭제
         )
         .map { _ in () }
         .retry(maxRetries)
@@ -548,7 +548,6 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
             return Observable.error(GroupExitError.dataCleanupFailed(error.localizedDescription))
         }
     }
-
 
     /// 롤백 시도 (베스트 에포트) (새로운 DB 구조 반영)
     private func attemptRollback(

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/ProfileViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewModel/ProfileViewModel.swift
@@ -137,7 +137,7 @@ final class ProfileViewModel: ViewModelProtocol {
         } else {
             state.shouldShowConfirmAlert.accept((
                 "'\(currentUser.groupName)' 그룹에서 탈퇴하시겠어요?",
-                "탈퇴 후 복구는 불가능해요",
+                "탈퇴 후 복구는 불가능하며 그룹에서\n생성된 스티커와 미션이 모두 삭제됩니다.",
                 { [weak self] in
                     self?.performLeaveGroup()
                 }


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
STAMPIT-189

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 그룹 탈퇴도 받은 미션만 삭제 (기존은 받은 미션, 부여한 미션 전체 조회 후 삭제)
2. 서비스 탈퇴도 받은 미션만 삭제 (기존은 받은 미션, 부여한 미션 전체 조회 후 삭제)

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
```
    // 특정 사용자가 "받은" 미션만 삭제 (그룹 탈퇴 시 사용)
    func deleteReceivedMissions(userId: String, groupId: String) -> Observable<Void> {
        return fetchList(query: .byAssignee(userId, groupId: groupId))
            .flatMap { [weak self] missions -> Observable<Void> in
                guard let self = self else {
                    return Observable.error(MissionError.fetchFailed("MissionManager 인스턴스가 없습니다"))
                }
                guard !missions.isEmpty else {
                    return Observable.just(())
                }
                let deleteObservables = missions.map { mission in
                    self.delete(id: mission.documentID)
                }
                return Observable.zip(deleteObservables).map { _ in () }
            }
    }
```
위 내용으로 받은 미션만 조회해서 삭제합니다. 그룹탈퇴, 서비스 탈퇴 시 모두 미션 삭제는 위 메서드만 사용합니다.

