### PR TITLE
[HotFix] STAMPIT-192 - 순차 방식으로 cleanupUserDataWithRetry 수정

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionProtocol.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionProtocol.swift
@@ -20,4 +20,5 @@ protocol MissionManagerProtocol: FullCRUDRepository where Entity == MissionFires
     func fetchMissions(to assigneeId: String?, by assignerId: String?, ofGroup groupId: String) -> Observable<[MissionFirestore]>
     func deleteUserMissions(userId: String, groupId: String) -> Observable<Void>
     func deleteGroupMissions(groupId: String) -> Observable<Void>
+    func deleteReceivedMissions(userId: String, groupId: String) -> Observable<Void>
 }

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
@@ -537,10 +537,10 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
         currentGroupId: String,
         maxRetries: Int
     ) -> Observable<Void> {
-        return missionManager.deleteReceivedMissions(userId: userId, groupId: currentGroupId)
+        return stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)
             .retry(maxRetries)
             .flatMap { _ in
-                return self.stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)
+                return self.missionManager.deleteReceivedMissions(userId: userId, groupId: currentGroupId)
                     .retry(maxRetries)
             }
             .timeout(.seconds(5), scheduler: MainScheduler.instance)

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/AccountManageRepositoryImpl.swift
@@ -287,10 +287,10 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
                     return Observable.error(RepositoryError.unknownError)
                 }
 
-                // 💡 그룹 탈퇴 전용 검증
+                // 그룹 탈퇴 전용 검증
                 return self.validateGroupLeaving(currentUser: currentUser)
                     .flatMap { _ in
-                        // 💡 그룹 탈퇴 실행
+                        // 그룹 탈퇴 실행
                         return self.executeGroupLeaving(currentUser: currentUser)
                     }
             }
@@ -334,7 +334,7 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
                 return self.membershipManager.fetchList(query: .byGroup(currentUser.groupID))
                     .map { memberships in memberships.count }
                     .flatMap { memberCount -> Observable<Void> in
-                        // 💡 핵심: 1인 그룹은 그룹 탈퇴 차단
+                        // 핵심: 1인 그룹은 그룹 탈퇴 차단
                         if memberCount <= 1 {
                             return Observable.error(
                                 RepositoryError.dataError("계정 삭제를 원하신다면\n'서비스 탈퇴'를 이용해주세요.")
@@ -537,16 +537,16 @@ final class AccountManageRepository: AccountManageRepositoryProtocol {
         currentGroupId: String,
         maxRetries: Int
     ) -> Observable<Void> {
-        return Observable.zip(
-            missionManager.deleteReceivedMissions(userId: userId, groupId: currentGroupId), // 받은 미션만 삭제
-            stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)      // 그룹과 관련된 본인 스티커 삭제
-        )
-        .map { _ in () }
-        .retry(maxRetries)
-        .timeout(.seconds(5), scheduler: MainScheduler.instance)
-        .catch { error in
-            return Observable.error(GroupExitError.dataCleanupFailed(error.localizedDescription))
-        }
+        return missionManager.deleteReceivedMissions(userId: userId, groupId: currentGroupId)
+            .retry(maxRetries)
+            .flatMap { _ in
+                return self.stickerManager.deleteUserStickers(userId: userId, groupId: currentGroupId)
+                    .retry(maxRetries)
+            }
+            .timeout(.seconds(5), scheduler: MainScheduler.instance)
+            .catch { error in
+                return Observable.error(GroupExitError.dataCleanupFailed(error.localizedDescription))
+            }
     }
 
     /// 롤백 시도 (베스트 에포트) (새로운 DB 구조 반영)


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-192

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 인터페이스 불일치 수정(프로토콜에 추가)
2. 그룹탈퇴, 서비스 탈퇴 시 미션을 완전히 지운 후 스티커를 지울 수 있도록 함.
3. 이전에는 zip으로 묶어 하나라도 성공하면 데이터 불일치 문제가 발생
4. 다른 zip도 확인 후 반영이 꼭 필요한 부분은 적용할 예정