### PR TITLE
[Hotfix] STAMPIT-192 - 그룹탈퇴 시 토스트 안 보이는 문제 해결 (빈배열 무한 대기 처리 로직 추가)

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Mission/MissionManager.swift
@@ -324,19 +324,16 @@ final class MissionManager: MissionManagerProtocol {
             
             let allMissions = assignedMissions + assignedByMissions
             
-            // 삭제할 미션이 없으면 바로 성공 반환
+            // 빈 배열 처리
             guard !allMissions.isEmpty else {
                 return Observable.just(())
             }
             
-            // 각 미션 삭제
             let deleteObservables = allMissions.map { mission in
                 self.delete(id: mission.documentID)
             }
             
-            // 모든 삭제 작업 완료 대기
-            return Observable.zip(deleteObservables)
-                .map { _ in () } // [Void] → Void 변환
+            return Observable.zip(deleteObservables).map { _ in () }
         }
     }
     
@@ -347,12 +344,16 @@ final class MissionManager: MissionManagerProtocol {
                 guard let self = self else {
                     return Observable.error(MissionError.fetchFailed("MissionManager 인스턴스가 없습니다"))
                 }
+                
+                // 빈 배열 처리
                 guard !missions.isEmpty else {
                     return Observable.just(())
                 }
+                
                 let deleteObservables = missions.map { mission in
                     self.delete(id: mission.documentID)
                 }
+                
                 return Observable.zip(deleteObservables).map { _ in () }
             }
     }
@@ -365,19 +366,16 @@ final class MissionManager: MissionManagerProtocol {
                     return Observable.error(MissionError.fetchFailed("MissionManager 인스턴스가 없습니다"))
                 }
                 
-                // 삭제할 미션이 없으면 바로 성공 반환
+                // 빈 배열 처리
                 guard !missions.isEmpty else {
                     return Observable.just(())
                 }
                 
-                // 각 미션 삭제
                 let deleteObservables = missions.map { mission in
                     self.delete(id: mission.documentID)
                 }
                 
-                // 모든 삭제 작업 완료 대기
-                return Observable.zip(deleteObservables)
-                    .map { _ in () } // [Void] → Void 변환
+                return Observable.zip(deleteObservables).map { _ in () }
             }
     }
 }

--- a/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Sticker/StickerManager.swift
+++ b/StampIt-Project/StampIt-Project/Data/DataSources/Manager/Sticker/StickerManager.swift
@@ -332,13 +332,19 @@ final class StickerManager: StickerManagerProtocol {
                 return Observable.error(StickerError.fetchFailed("StickerManager 인스턴스가 없습니다"))
             }
             
+            // 빈 배열 처리
+            guard !stickers.isEmpty else {
+                return Observable.just(())
+            }
+            
             let deleteObservables = stickers.map { sticker in
                 self.delete(id: sticker.documentID)
             }
+            
             return Observable.zip(deleteObservables).map { _ in () }
         }
     }
-    
+
     /// 사용자의 모든 스티커 삭제 (서비스 탈퇴용)
     func deleteUserStickers(userId: String) -> Observable<Void> {
         return fetchList(query: StickerQuery(
@@ -366,11 +372,10 @@ final class StickerManager: StickerManagerProtocol {
                 self.delete(id: sticker.documentID)
             }
             
-            return Observable.zip(deleteObservables)
-                .map { _ in () }
+            return Observable.zip(deleteObservables).map { _ in () }
         }
     }
-    
+
     /// 특정 그룹의 모든 스티커 삭제 (그룹 삭제 시 사용)
     func deleteGroupStickers(groupId: String) -> Observable<Void> {
         return fetchList(query: .byGroup(groupId))
@@ -379,9 +384,15 @@ final class StickerManager: StickerManagerProtocol {
                     return Observable.error(StickerError.fetchFailed("StickerManager 인스턴스가 없습니다"))
                 }
                 
+                // 빈 배열 처리
+                guard !stickers.isEmpty else {
+                    return Observable.just(())
+                }
+                
                 let deleteObservables = stickers.map { sticker in
                     self.delete(id: sticker.documentID)
                 }
+                
                 return Observable.zip(deleteObservables).map { _ in () }
             }
     }


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-192

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. StickerManager 삭제 메서드에서 빈 배열 처리 로직 추가
- deleteUserStickers(userId:groupId:)에서 Observable.zip 빈 배열 무한 대기 문제 해결
- deleteUserStickers(userId:)에서 빈 배열 체크 로직 추가  
- deleteGroupStickers(groupId:)에서 빈 배열 체크 로직 추가
- Observable.zip([]) 호출 시 무한 대기되는 RxSwift 특성 대응
- 삭제할 스티커가 없을 경우 Observable.just(())로 즉시 성공 반환

2. MissionManager 삭제 메서드에서 빈 배열 처리 로직 추가
- deleteUserMissions(userId:groupId:)에서 Observable.zip 빈 배열 무한 대기 문제 해결
- deleteReceivedMissions(userId:groupId:)에서 빈 배열 체크 로직 추가
- deleteGroupMissions(groupId:)에서 빈 배열 체크 로직 추가  
- Observable.zip([]) 호출 시 무한 대기되는 RxSwift 특성 대응
- 삭제할 미션이 없을 경우 Observable.just(())로 즉시 성공 반환


## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/26f4ae23-0e20-4191-ab32-3eb17a1ac3c4" width ="250">|