### PR TITLE
[Fix] STAMPIT-196 - 커스텀 미션 제목 작성할 때 키보드 내려가지 않는 현상 해결

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -102,6 +102,8 @@ final class AssignMissionViewController: UIViewController {
         if viewModel.state.mission.value?.category == .custom {
             navigationBar.updateNavigationTitle("커스텀 미션 전달하기")
         }
+        
+        setTapGesture()
     }
     
     private func prepareSubviews() {
@@ -287,5 +289,15 @@ final class AssignMissionViewController: UIViewController {
     // 전달하기 버튼 누르면 원래 화면으로 복귀
     private func dismiss() {
         navigationController?.popViewController(animated: true)
+    }
+    
+    private func setTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-196

## 📌 변경 사항 및 이유
- 같은 실수가 반복되서 면목이 없네요. 다른 화면도 키보드 온 상태에서 모두 확인했습니다.

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![Simulator Screen Recording - iPhone 16 Pro - 2025-07-02 at 15 27 19](https://github.com/user-attachments/assets/072a8e0f-3edc-4a30-8f29-c46e85e05567)|

## 📌 PR Point
없음

## 📌 참고 사항
앞으로 푸쉬 전 최종 테스트는 무조건 키보드 온 상태에서 해야겠습니다.