### PR TITLE
[Feat] STAMPIT-197 - 카테고리 필터 버튼에 "즐겨찾기" 추가

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -142,7 +142,9 @@ final class MissionListViewController: UIViewController {
                 guard let self else { return }
                 
                 let favorites = viewModel.state.favorites.value
-                if favorites.contains(element.missionId) {
+                let isOnlyFavorites = viewModel.state.isOnlyFavorite.value
+                
+                if favorites.contains(element.missionId), !isOnlyFavorites {
                     cell.configure(with: element.title, isFavorite: true)
                 } else {
                     cell.configure(with: element.title, isFavorite: false)
@@ -188,7 +190,14 @@ final class MissionListViewController: UIViewController {
             .drive { [weak self] results in
                 guard let self else { return }
                 
-                if results.isEmpty {
+                let isOnlyFavorites = viewModel.state.isOnlyFavorite.value
+                let favorites = viewModel.state.favorites.value
+                
+                if isOnlyFavorites, favorites.isEmpty {
+                    noResultsView.configureContent(title: "즐겨찾기가 없어요", description: "미션을 스와이프해서 즐겨찾기에 추가하세요")
+                    tableView.backgroundView = noResultsView
+                } else if results.isEmpty {
+                    noResultsView.configureContent(title: "검색 결과가 없어요", description: "다른 검색어로 검색해보세요")
                     tableView.backgroundView = noResultsView
                 } else {
                     tableView.backgroundView = nil
@@ -252,6 +261,10 @@ final class MissionListViewController: UIViewController {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FilterCell.reuseIdentifier, for: indexPath) as! FilterCell
                 cell.configure(title: "전체보기", titleColor: .white, backgroundColor: .red400)
                 return cell
+            case .favorite:
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FilterCell.reuseIdentifier, for: indexPath) as! FilterCell
+                cell.configure(title: "즐겨찾기", titleColor: .white, backgroundColor: .red400)
+                return cell
             case .category(let category):
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FilterCell.reuseIdentifier, for: indexPath) as! FilterCell
                 cell.configure(image: category.image, title: category.title, titleColor: .gray400, backgroundColor: .white)
@@ -264,7 +277,7 @@ final class MissionListViewController: UIViewController {
     private func updateSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([.category])
-        snapshot.appendItems([.all, .category(.chore), .category(.communication), .category(.health), .category(.learning)])
+        snapshot.appendItems([.all, .favorite, .category(.chore), .category(.communication), .category(.health), .category(.learning)])
         
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
@@ -324,6 +337,7 @@ extension MissionListViewController {
     
     enum Item: Hashable {
         case all
+        case favorite
         case category(MissionCategory)
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
@@ -20,7 +20,6 @@ final class MissionListCell: UITableViewCell {
     
     private let favoriteImageView = UIImageView().then {
         $0.image = UIImage(named: "bookmarkRed")
-        $0.tintColor = .red200
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -23,6 +23,7 @@ final class MissionListViewModel: ViewModelProtocol {
         var searchText = BehaviorRelay<String>(value: "")
         var selectedCategory = BehaviorRelay<MissionCategory?>(value: nil)
         var favorites = BehaviorRelay<Set<String>>(value: [])
+        var isOnlyFavorite = BehaviorRelay<Bool>(value: false) // 즐겨찾기 등록된 미션만 보여줘야 하는지 true/false
     }
     
     var action = PublishRelay<Action>()
@@ -69,10 +70,16 @@ final class MissionListViewModel: ViewModelProtocol {
                 case .didSelectCollectionViewCell(let indexPath):
                     if indexPath.item == 0 {
                         state.selectedCategory.accept(nil)
+                        state.isOnlyFavorite.accept(false)
                         print("전체보기")
+                    } else if indexPath.item == 1 {
+                        state.selectedCategory.accept(nil)
+                        state.isOnlyFavorite.accept(true)
+                        print("즐겨찾기")
                     } else {
-                        let category = MissionCategory.allCases[indexPath.item - 1]
+                        let category = MissionCategory.allCases[indexPath.item - 2]
                         state.selectedCategory.accept(category)
+                        state.isOnlyFavorite.accept(false)
                         print("category: \(category.title)")
                     }
                 case .toggleFavorite(let indexPath):
@@ -94,8 +101,8 @@ final class MissionListViewModel: ViewModelProtocol {
     
     // 미션 검색 + 카테고리 선택
     private func bindFilterMisson() {
-        Observable.combineLatest(state.searchText, state.selectedCategory, state.favorites)
-            .map { [weak self] searchText, selectedCategory, _ -> [SampleMission] in
+        Observable.combineLatest(state.searchText, state.selectedCategory, state.isOnlyFavorite, state.favorites)
+            .map { [weak self] searchText, selectedCategory, isOnlyFavorite, favorites -> [SampleMission] in
                 guard let self else { return [] }
                 
                 // 단어 단위로 분할
@@ -105,6 +112,11 @@ final class MissionListViewModel: ViewModelProtocol {
                     .filter { !$0.isEmpty }
                 
                 let filteredMissions = _missions.filter { mission in
+                    // 즐겨찾기 필터
+                    if isOnlyFavorite, !favorites.contains(mission.missionId) {
+                        return false
+                    }
+                    
                     // 카테고리 필터
                     if let category = selectedCategory, mission.category != category {
                         return false


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-197

## 📌 변경 사항 및 이유
- 카테고리 필터 버튼에 "즐겨찾기" 추가

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![Simulator Screen Recording - iPhone 16 Pro - 2025-07-03 at 09 20 23](https://github.com/user-attachments/assets/ee809fe0-0385-476f-b161-df3a56fc7332)|

## 📌 PR Point
- 보여질 미션이 없을 때 원래 "검색 결과 없음"을 보여주게 되어 있으나, "즐겨찾기"가 없는 상태에서 즐겨찾기 카테고리를 선택했을 때는 "즐겨찾기 없음"을 보여주게 했습니다(이건 피그마에 없는 사항이나 일단 반영했습니다)
- 구현 방법을 2가지 생각했는데 더 간단한 1번으로 했습니다. 하지만 장기적으로는 2번도 괜찮을 수 있을거 같습니다.
- 1) 컬렉션 뷰 item 수정: 기존 all(전체보기), category(각 카테고리) -> favorite(즐겨찾기) 하나 더 추가
- 2) 미션 카테고리 수정: 기존 각 카테고리(집안일 등...), custom(커스텀 미션) -> favorite(즐겨찾기) 하나 더 추가
2번은 여러가지 상황에 더 유연하게 대응할 수 있지만, 즐겨찾기 해제 시 기존 카테고리를 확인해서 다시 원복해야 하는 로직 상 복잡성이 있고, 모델 변경이라 다른 화면에도 영향을 줄 것 같아 패스했습니다.

## 📌 참고 사항
- 아직 두 가지 구현 안되어 있습니다.
- 1) 즐겨찾기 해제 시 토스트 메시지 띄우기: 키보드가 올라온 상황이 있을 수 있어 이거 먼저 해결해야 합니다.
- 2) 즐겨찾기 카테고리에서 스와이프 아이콘 휴지통: 기능 상으로는 즐겨찾기 해제이지만, 사용자가 미션 삭제로 오인할 수 있다는 다은님의 의견이 있어 보류했습니다.