### PR TITLE
[Feat] STAMPIT-184 홈화면에서의 미션완료 취소 로직 개선

### DIFF
--- a/StampIt-Project/StampIt-Project/Domain/Entities/Mission.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/Mission.swift
@@ -22,10 +22,6 @@ struct Mission: Equatable {
         dueDate.daysFromToday() < 0
     }
 
-    var isCancelableCompleted: Bool {
-        status == .completed && !isOverdue
-    }
-
     var isNew: Bool {
         let today = Calendar.current.dateComponents([.day], from: Date())
         let created = Calendar.current.dateComponents([.day], from: createDate)

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Component/CustomToastView.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Component/CustomToastView.swift
@@ -14,11 +14,10 @@ import RxCocoa
 final class ToastView: UIView {
 
     let didTapCancelButton = PublishRelay<Void>()
-    private let disposeBag = DisposeBag()
+    let disposeBag = DisposeBag()
 
     private let iconImageView = UIImageView().then {
         $0.image = UIImage(named: "CheckCircleColored")
-//        $0.tintColor = UIColor(.red400)
     }
 
     private let contentStackView = UIStackView().then {
@@ -96,12 +95,13 @@ final class ToastView: UIView {
     // MARK: - Show Toast
     func show(in view: UIView, duration: TimeInterval = 2.0, message: String, type: ToastType) {
         //이미 띄어진 경우 방지
-        iconImageView.image = type.icon
-        iconImageView.tintColor = type.tintColor
-        messageLabel.text = message
         if self.superview != nil { return }
         view.addSubview(self)
         self.alpha = 0
+
+        iconImageView.image = type.icon
+        iconImageView.tintColor = type.tintColor
+        messageLabel.text = message
 
         self.snp.makeConstraints {
             $0.centerX.equalToSuperview()

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Mapper/MissionMapper.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Mapper/MissionMapper.swift
@@ -21,7 +21,6 @@ final class MissionMapper: MissionMapping {
                 assigner: assigner,
                 isNew: mission.isNew,
                 isOverdue: mission.isOverdue,
-                isCancelableCompleted: mission.isCancelableCompleted,
                 status: mission.status
             )
             return homeMission

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Common/AssignedMissionCell.swift
@@ -250,7 +250,7 @@ final class AssignedMissionCell: UICollectionViewCell {
         dateTag.updateText(with: "~" + mission.dueDate)
         dateTag.updateTextColor(mission.isOverdue ? .gray200 : .gray400)
         titleLabel.text = mission.title
-        statusButton.updateStatus(to: mission.status, mission.isCancelableCompleted)
+        statusButton.updateStatus(to: mission.status, !mission.isOverdue)
         updateContentStackViewConstraints()
     }
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Model/HomeItem.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Model/HomeItem.swift
@@ -91,7 +91,6 @@ struct HomeMyMission: Hashable {
     let assigner: String
     let isNew: Bool
     let isOverdue: Bool
-    let isCancelableCompleted: Bool
     let status: MissionStatus
 
     func makeCopy(status: MissionStatus) -> HomeMyMission {
@@ -103,7 +102,6 @@ struct HomeMyMission: Hashable {
             assigner: self.assigner,
             isNew: self.isNew,
             isOverdue: self.isOverdue,
-            isCancelableCompleted: self.isCancelableCompleted,
             status: status
         )
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/ViewModel/MyMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/MyMission/ViewModel/MyMissionViewModel.swift
@@ -124,7 +124,7 @@ final class MyMissionViewModel: ViewModelProtocol {
         case .assigned:
             handleMissionCompleteButtonTapped(missionID: mission.missionID)
         case .completed:
-            guard mission.isCancelableCompleted else { return }
+            guard !mission.isOverdue else { return }
             handleCancelMissionComplete(missionID: mission.missionID)
         case .failed: break
         }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
@@ -43,11 +43,6 @@ final class HomeViewController: UIViewController {
         bind()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.action.accept(.viewWillAppear)
-    }
-
     // MARK: - Set Styles
 
     private func setStyles() {
@@ -80,6 +75,7 @@ final class HomeViewController: UIViewController {
     // MARK: - Bind
 
     private func bind() {
+        viewModel.action.accept(.viewDidLoad)
         bindGroupOrganizationView()
         bindDashboardView()
         bindToastView()

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
@@ -22,7 +22,7 @@ final class HomeViewController: UIViewController {
 
     private let navigationBar = DefaultNavigationBar(.logoWithItem)
     private let homeView = HomeView()
-    private let toastView = ToastView(withCancelButton: true)
+    private var activeToasts: [String: ToastView] = [:] // key: missionID
 
     // MARK: - Life Cycles
 
@@ -193,27 +193,39 @@ final class HomeViewController: UIViewController {
     }
 
     private func bindToastView() {
-        toastView.didTapCancelButton
-            .map { HomeViewModel.Action.didTapCompleteCancelButton }
-            .bind(to: viewModel.action)
+        viewModel.state.completionCanceledMission
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, missionID in
+                owner.activeToasts[missionID]?.dismiss(duration: 0)
+                owner.activeToasts[missionID] = nil
+            }
             .disposed(by: disposeBag)
 
-        Observable.combineLatest(
-            viewModel.state.isShowStickerReceived,
-            viewModel.state.completedMissionTitle
-        )
-        .asDriver(onErrorDriveWith: .empty())
-        .drive { [weak self] show, missionTitle in
-            guard let self else { return }
-            if show {
-                let message = "'\(missionTitle.truncatedTo10)' 미션을 완료했어요!"
-                toastView.show(in: homeView, duration: 3, message: message, type: .success)
-            } else {
-                toastView.dismiss(duration: 0)
+        viewModel.state.isShowStampReceived
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, value in
+                let (missionID, message) = value
+                let toastView = ToastView(withCancelButton: true)
+                owner.activeToasts[missionID] = toastView
+
+                toastView.show(in: owner.homeView, duration: 3, message: message, type: .success)
+
+                Observable.just(())
+                    .delay(.seconds(3), scheduler: MainScheduler.instance)
+                    .take(until: toastView.didTapCancelButton)
+                    .bind(with: self) { owner, _ in
+                        owner.activeToasts[missionID] = nil
+                    }
+                    .disposed(by: toastView.disposeBag)
+
+                toastView.didTapCancelButton
+                    .map { HomeViewModel.Action.didTapCompleteCancelButton }
+                    .bind(to: owner.viewModel.action)
+                    .disposed(by: toastView.disposeBag)
             }
-        }
-        .disposed(by: disposeBag)
+            .disposed(by: disposeBag)
     }
+
 
     // MARK: - Methods
 

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -55,8 +55,6 @@ final class HomeViewModel: ViewModelProtocol {
     var memberCache = [String: Member]() // 멤버 정보 저장
     private var myMissions = [Mission]() // Firestore 상태 업데이트용 도메인 미션 캐시
     private var memberMissions = [Mission]()
-    private var pendingMissions = [String]()
-    private var pendingCommits = DisposeBag()
 
     // MARK: - Init
 
@@ -156,13 +154,7 @@ final class HomeViewModel: ViewModelProtocol {
               self.myMissions = missions
               let items = self.missionMapper
                   .map(myMissions: missions, member: memberCache)
-                  .compactMap { mission -> HomeItem? in
-                      if self.pendingMissions.contains(mission.missionID) {
-                          return nil
-                      } else {
-                          return HomeItem.myMission(mission)
-                      }
-                  }
+                  .map { HomeItem.myMission($0) }
               self.state.myMissions.accept(items)
           })
           .disposed(by: disposeBag)
@@ -219,27 +211,18 @@ final class HomeViewModel: ViewModelProtocol {
     /// 미션 완료 API를 호출하고,
     /// 전달받은 미션의 ID로 myMissions에서 해당 미션을 찾아 제거, 스티커 생성
     func handleMissionCompleteButtonTapped(missionID: String) {
-        guard let user = state.user.value else { return }
+        guard let user = state.user.value,
+              let mission = removeMissionCache(missionID: missionID) else { return }
         removeMissionItem(missionID: missionID)
         state.isShowStickerReceived.accept(true)
-        pendingMissions.append(missionID)
 
-        // cancelMissionComplete() 호출 시 dispose되는 Observable
-        Observable<Void>.just(())
-            .delay(.seconds(3), scheduler: MainScheduler.instance)
-            .flatMap { [weak self] _ -> Observable<Mission> in
-                guard let self else { return .empty() }
-                let removedMission = removeMissionCache(missionID: missionID)
-                guard let mission = removedMission else { return .empty() }
-                pendingMissions.remove(at: pendingMissions.firstIndex(of: missionID)!)
-                return myMissionUseCase.updateMissionStatus(for: mission, ofGroup: user.groupID, to: .completed)
-            }
+        myMissionUseCase.updateMissionStatus(for: mission, ofGroup: user.groupID, to: .completed)
             .flatMap { [weak self] mission -> Observable<Void> in
                 guard let self else { return .empty() }
                 return myMissionUseCase.createSticker(user: user, mission: mission)
             }
             .subscribe()
-            .disposed(by: pendingCommits)
+            .disposed(by: disposeBag)
     }
 
     /// UI에서 미션 제거
@@ -257,8 +240,6 @@ final class HomeViewModel: ViewModelProtocol {
 
     /// 토스트 “취소하기” 버튼 눌렀을 때 호출
     func cancelMissionComplete() {
-        pendingCommits = DisposeBag()
-//        pendingMissions = []
         let cachedMissions = missionMapper
             .map(myMissions: myMissions, member: memberCache)
             .map { HomeItem.myMission($0) }
@@ -269,6 +250,8 @@ final class HomeViewModel: ViewModelProtocol {
     // MARK: - Methods
 
     /// fetch 전 placeholder 제공
+    ///
+    /// TODO: 뷰를 로드할 때마다 깜빡임
     private func showPlaceholderOnSendedSection() {
         state.memberMissionsForDisplay.accept([])
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -80,7 +80,6 @@ final class HomeViewModel: ViewModelProtocol {
             .subscribe(with: self) { owner, action in
                 switch action {
                 case .viewWillAppear:
-                    owner.showPlaceholderOnSendedSection()
                     owner.bindUser()
                 case .didTapGroupOrganizationButton:
                     owner.handleSelectIvitation()
@@ -258,14 +257,5 @@ final class HomeViewModel: ViewModelProtocol {
     private func findMissionFromCache(missionID: String) -> Mission? {
         guard let index = myMissions.firstIndex(where: { $0.missionID == missionID }) else { return nil }
         return myMissions[index]
-    }
-
-    // MARK: - Methods
-
-    /// fetch 전 placeholder 제공
-    ///
-    /// TODO: 뷰를 로드할 때마다 깜빡임
-    private func showPlaceholderOnSendedSection() {
-        state.memberMissionsForDisplay.accept([])
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -21,7 +21,7 @@ final class HomeViewModel: ViewModelProtocol {
     // MARK: - Action & State
 
     enum Action {
-        case viewWillAppear
+        case viewDidLoad
         case didTapGroupOrganizationButton
         case didReceiveInvitationType(InvitationType)
         case didTapMissonCompleteButton(HomeItem)
@@ -79,7 +79,7 @@ final class HomeViewModel: ViewModelProtocol {
         action
             .subscribe(with: self) { owner, action in
                 switch action {
-                case .viewWillAppear:
+                case .viewDidLoad:
                     owner.bindUser()
                 case .didTapGroupOrganizationButton:
                     owner.handleSelectIvitation()

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -41,8 +41,8 @@ final class HomeViewModel: ViewModelProtocol {
         let isShowSelectInvitationVC = PublishRelay<Void>()
         let isPushSendInvitationVC = PublishRelay<Void>()
         let isPushReceiveInvitationVC = PublishRelay<Void>()
-        let completedMissionTitle = BehaviorRelay<String>(value: "")
-        let isShowStickerReceived = PublishRelay<Bool>()
+        let isShowStampReceived = PublishRelay<(String, String)>()
+        let completionCanceledMission = PublishRelay<String>()
         let isPushMyMissionVC = PublishRelay<Void>()
         let isPushMemberMissionVC = PublishRelay<Void>()
     }
@@ -55,6 +55,7 @@ final class HomeViewModel: ViewModelProtocol {
     var memberCache = [String: Member]() // 멤버 정보 저장
     private var myMissions = [Mission]() // Firestore 상태 업데이트용 도메인 미션 캐시
     private var memberMissions = [Mission]()
+    private var pendingStack: [Mission] = [] // 취소 가능한 미션 (3초 보관)
 
     // MARK: - Init
 
@@ -86,11 +87,10 @@ final class HomeViewModel: ViewModelProtocol {
                 case .didReceiveInvitationType(let type):
                     owner.handleInvitation(type: type)
                 case .didTapMissonCompleteButton(let item):
-                    let missionID = item.myMission!.missionID
-                    owner.handleMissionCompleteButtonTapped(missionID: missionID)
-                    owner.state.completedMissionTitle.accept(item.myMission!.title)
+                    let mission = item.myMission!
+                    owner.handleMissionCompleteButtonTapped(missionID: mission.missionID)
                 case .didTapCompleteCancelButton:
-                    owner.cancelMissionComplete()
+                    owner.handleCancelMissionComplete()
                 case .didTapMoreMyMissions:
                     owner.state.isPushMyMissionVC.accept(())
                 case .didSelectReceivedMember(let index):
@@ -208,14 +208,25 @@ final class HomeViewModel: ViewModelProtocol {
 
     /// 미션 완료 바인딩
     ///
-    /// 미션 완료 API를 호출하고,
-    /// 전달받은 미션의 ID로 myMissions에서 해당 미션을 찾아 제거, 스티커 생성
+    /// myMissions에서 완료할 미션을 찾은 후 미션 완료 API를 호출하고 스티커 생성
     func handleMissionCompleteButtonTapped(missionID: String) {
         guard let user = state.user.value,
-              let mission = removeMissionCache(missionID: missionID) else { return }
-        removeMissionItem(missionID: missionID)
-        state.isShowStickerReceived.accept(true)
+              let mission = findMissionFromCache(missionID: missionID) else { return }
 
+        let message = "'\(mission.title.truncatedTo10)' 미션을 완료했어요!"
+        state.isShowStampReceived.accept((missionID, message))
+        pendingStack.append(mission)
+
+        /// 3초 후 pending중인 미션 제거
+        Observable.just(())
+            .delay(.seconds(3), scheduler: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, _ in
+                guard !owner.pendingStack.isEmpty else { return }
+                owner.pendingStack.removeFirst()
+            })
+            .disposed(by: disposeBag)
+
+        // 미션 상태를 완료로 업데이트
         myMissionUseCase.updateMissionStatus(for: mission, ofGroup: user.groupID, to: .completed)
             .flatMap { [weak self] mission -> Observable<Void> in
                 guard let self else { return .empty() }
@@ -225,26 +236,28 @@ final class HomeViewModel: ViewModelProtocol {
             .disposed(by: disposeBag)
     }
 
-    /// UI에서 미션 제거
-    private func removeMissionItem(missionID: String) {
-        let missions = state.myMissions.value
-        let updated = missions.filter { $0.myMission!.missionID != missionID }
-        state.myMissions.accept(updated)
-    }
-
-    /// 도메인 미션 캐시에서 미션 제거
-    private func removeMissionCache(missionID: String) -> Mission? {
-        guard let index = myMissions.firstIndex(where: { $0.missionID == missionID }) else { return nil }
-        return myMissions.remove(at: index)
-    }
-
     /// 토스트 “취소하기” 버튼 눌렀을 때 호출
-    func cancelMissionComplete() {
-        let cachedMissions = missionMapper
-            .map(myMissions: myMissions, member: memberCache)
-            .map { HomeItem.myMission($0) }
-        state.myMissions.accept(cachedMissions)
-        state.isShowStickerReceived.accept(false)
+    private func handleCancelMissionComplete() {
+        guard !pendingStack.isEmpty else { return }
+        let mission = pendingStack.removeLast()
+        state.completionCanceledMission.accept(mission.missionID)
+
+        guard let user = state.user.value else { return }
+
+        /// 미션 상태를 진행중으로 롤백
+        myMissionUseCase.updateMissionStatus(for: mission, ofGroup: user.groupID, to: .assigned)
+            .flatMap { [weak self] mission -> Observable<Void> in
+                guard let self else { return .empty() }
+                return myMissionUseCase.deleteSticker(missionID: mission.missionID)
+            }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+
+    /// 도메인 미션 찾기
+    private func findMissionFromCache(missionID: String) -> Mission? {
+        guard let index = myMissions.firstIndex(where: { $0.missionID == missionID }) else { return nil }
+        return myMissions[index]
     }
 
     // MARK: - Methods


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-184


## 📌 변경 사항 및 이유
- Mission 엔티티의 isCancelableCompleted를 삭제하고 isOverdue를 활용할 수 있도록 변경
- UI를 먼저 업데이트하고 시간이 지나면 API를 호출했었는데, 즉시 호출하여 취소를 누르면 취소API를 호출하도록 변경
- 개별적으로 완료를 취소할 수 있도록 개선


## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/550d4686-f122-48a6-8721-49930650282c" width ="250">|


## 📌 PR Point
-


## 📌 참고 사항
-
