### PR TITLE
[Feat] STAMPIT-201 - 추천 미션 제안 기능 구현

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -143,11 +143,16 @@ final class MissionListViewController: UIViewController {
                 
                 let favorites = viewModel.state.favorites.value
                 let isOnlyFavorites = viewModel.state.isOnlyFavorite.value
+                let recommendedMissions = viewModel.state.recommendedMissions
+                let isFavorite = favorites.contains(element.missionId)
+                let isRecommended = recommendedMissions.contains(where: { $0.missionId == element.missionId })
                 
-                if favorites.contains(element.missionId), !isOnlyFavorites {
-                    cell.configure(with: element.title, isFavorite: true)
+                if isFavorite, !isOnlyFavorites {
+                    cell.configure(with: element.title, isFavorite: true, isRecommended: false)
+                } else if isRecommended, !isOnlyFavorites {
+                    cell.configure(with: element.title, isFavorite: false, isRecommended: true)
                 } else {
-                    cell.configure(with: element.title, isFavorite: false)
+                    cell.configure(with: element.title, isFavorite: false, isRecommended: false)
                 }
             }
             .disposed(by: disposeBag)

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -244,6 +244,7 @@ final class MissionListViewController: UIViewController {
         viewModel.onSuccess = { [weak self] in
             guard let self else { return }
             toastView.show(in: view, duration: 3, message: "미션이 전달되었어요", type: .success)
+            self.viewModel.donate(.assignMission, to: mission)
         }
         let viewController = AssignMissionViewController(viewModel: viewModel)
         navigationController?.pushViewController(viewController, animated: true)

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/Subview/MissionListCell.swift
@@ -22,10 +22,24 @@ final class MissionListCell: UITableViewCell {
         $0.image = UIImage(named: "bookmarkRed")
     }
     
+    private let recommendationLabel = UILabel().then {
+        $0.text = "추천"
+        $0.font = .pretendard(size: 12, weight: .regular)
+        $0.textColor = .gray600
+        $0.backgroundColor = .gray50
+        $0.textAlignment = .center
+        $0.layer.cornerRadius = 10
+        $0.clipsToBounds = true
+        
+        $0.isHidden = true
+        $0.setContentHuggingPriority(.required, for: .horizontal)
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        [label, favoriteImageView].forEach { addSubview($0) }
+        [label, favoriteImageView, recommendationLabel].forEach { addSubview($0) }
         
         setConstraints()
         
@@ -47,17 +61,32 @@ final class MissionListCell: UITableViewCell {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(32)
         }
+        
+        recommendationLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(18)
+            $0.height.equalTo(20)
+            $0.width.greaterThanOrEqualTo(40)
+        }
     }
     
     /// 테이블 뷰 셀 업데이트
-    /// - Parameter text: 미션 타이틀(예: 방 청소하기)
-    func configure(with text: String, isFavorite: Bool) {
+    /// - Parameters:
+    ///   - text: 미션 타이틀(예: 방 청소하기)
+    ///   - isFavorite: 즐겨찾기 여부
+    ///   - isRecommended: 추천 미션 여부
+    func configure(with text: String, isFavorite: Bool, isRecommended: Bool) {
         label.text = text
         
         if isFavorite {
             favoriteImageView.isHidden = false
+            recommendationLabel.isHidden = true
+        } else if isRecommended {
+            favoriteImageView.isHidden = true
+            recommendationLabel.isHidden = false
         } else {
             favoriteImageView.isHidden = true
+            recommendationLabel.isHidden = true
         }
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -101,8 +101,12 @@ final class AssignMissionViewModel: ViewModelProtocol {
                     print("did tap assign button")
                     createMission()
                         .subscribe { [weak self] in
+                            guard let self else { return }
                             print("mission created.")
-                            self?.onSuccess?()
+                            onSuccess?()
+                            if let mission = state.mission.value, mission.missionId != "" {
+                                donate(.assignMission, to: mission)
+                            }
                         } onError: { error in
                             print(error)
                         }
@@ -168,5 +172,17 @@ final class AssignMissionViewModel: ViewModelProtocol {
             category: state.mission.value!.category)
         
         return missionUseCaseImpl.createMission(groupId: user.groupID, mission: mission)
+    }
+    
+    // 미션별 추천 점수 적립
+    // 어떤 이벤트가 일어날 때, 해당 미션에 이벤트별 점수를 적립(예: 사용자가 미션 전달하기를 완료하면 해당 미션에 0.4점 부여)
+    private func donate(_ event: Event, to mission: SampleMission) {
+        var scores = UserDefaults.standard.dictionary(forKey: UserDefaultsKey.missionScores) as? [String: Double] ?? [:]
+        var score = scores[mission.missionId] ?? 0
+        
+        score += event.relevance // 이벤트별 점수를 적립
+        scores[mission.missionId] = score
+        
+        UserDefaults.standard.set(scores, forKey: UserDefaultsKey.missionScores)
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -101,12 +101,8 @@ final class AssignMissionViewModel: ViewModelProtocol {
                     print("did tap assign button")
                     createMission()
                         .subscribe { [weak self] in
-                            guard let self else { return }
                             print("mission created.")
-                            onSuccess?()
-                            if let mission = state.mission.value, mission.missionId != "" {
-                                donate(.assignMission, to: mission)
-                            }
+                            self?.onSuccess?()
                         } onError: { error in
                             print(error)
                         }
@@ -172,17 +168,5 @@ final class AssignMissionViewModel: ViewModelProtocol {
             category: state.mission.value!.category)
         
         return missionUseCaseImpl.createMission(groupId: user.groupID, mission: mission)
-    }
-    
-    // 미션별 추천 점수 적립
-    // 어떤 이벤트가 일어날 때, 해당 미션에 이벤트별 점수를 적립(예: 사용자가 미션 전달하기를 완료하면 해당 미션에 0.4점 부여)
-    private func donate(_ event: Event, to mission: SampleMission) {
-        var scores = UserDefaults.standard.dictionary(forKey: UserDefaultsKey.missionScores) as? [String: Double] ?? [:]
-        var score = scores[mission.missionId] ?? 0
-        
-        score += event.relevance // 이벤트별 점수를 적립
-        scores[mission.missionId] = score
-        
-        UserDefaults.standard.set(scores, forKey: UserDefaultsKey.missionScores)
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -187,7 +187,7 @@ final class MissionListViewModel: ViewModelProtocol {
     // 추천 미션 선정(최대 3개)
     private func recommend(among missions: [SampleMission]) -> [SampleMission] {
         let recommendedMissions = missions
-            .filter { (missionScores[$0.missionId] ?? 0) > 0 } // 점수가 0 초과인 미션만 추천(0은 추천 안함)
+            .filter { (missionScores[$0.missionId] ?? 0) >= 1.0 } // 점수가 1.0 이상인 미션만 추천
             .sorted { (missionScores[$0.missionId] ?? 0) > (missionScores[$1.missionId] ?? 0) } // 점수 순 정렬
             .prefix(3) // 상위 3개만 추출
         return Array(recommendedMissions)
@@ -195,7 +195,7 @@ final class MissionListViewModel: ViewModelProtocol {
     
     // 미션별 추천 점수 적립
     // 어떤 이벤트가 일어날 때, 해당 미션에 이벤트별 점수를 적립(예: 사용자가 미션 전달하기를 완료하면 해당 미션에 0.4점 부여)
-    private func donate(_ event: Event, to mission: SampleMission) {
+    func donate(_ event: Event, to mission: SampleMission) {
         var scores = missionScores
         var score = scores[mission.missionId] ?? 0
         

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -24,6 +24,7 @@ final class MissionListViewModel: ViewModelProtocol {
         var selectedCategory = BehaviorRelay<MissionCategory?>(value: nil)
         var favorites = BehaviorRelay<Set<String>>(value: [])
         var isOnlyFavorite = BehaviorRelay<Bool>(value: false) // 즐겨찾기 등록된 미션만 보여줘야 하는지 true/false
+        var recommendedMissions: [SampleMission] = []
     }
     
     var action = PublishRelay<Action>()
@@ -33,6 +34,7 @@ final class MissionListViewModel: ViewModelProtocol {
     
     private let missionUseCaseImpl: MissionUseCase
     private var _missions: [SampleMission] = [] // 샘플 미션 JSON 원본 데이터
+    private var missionScores: [String: Double] = [:] // 미션별 추천 점수
     
     init(missionUseCaseImpl: MissionUseCase) {
         self.missionUseCaseImpl = missionUseCaseImpl
@@ -42,6 +44,7 @@ final class MissionListViewModel: ViewModelProtocol {
         bindFilterMisson()
         
         loadFavorites()
+        loadMissionScores()
     }
     
     private func bind() {
@@ -67,6 +70,7 @@ final class MissionListViewModel: ViewModelProtocol {
                     print("searchText: \(searchText)")
                 case .didSelectTableViewCell(let mission):
                     print("didSelectTableViewCell: \(mission.title)")
+                    donate(.tapMission, to: mission)
                 case .didSelectCollectionViewCell(let indexPath):
                     if indexPath.item == 0 {
                         state.selectedCategory.accept(nil)
@@ -93,7 +97,7 @@ final class MissionListViewModel: ViewModelProtocol {
                         favorites.insert(mission.missionId)
                     }
                     state.favorites.accept(favorites)
-                    UserDefaults.standard.set(Array(favorites), forKey: "favorites")
+                    UserDefaults.standard.set(Array(favorites), forKey: UserDefaultsKey.favorites)
                 }
             }
             .disposed(by: disposeBag)
@@ -140,13 +144,14 @@ final class MissionListViewModel: ViewModelProtocol {
             .disposed(by: disposeBag)
     }
     
-    // 정렬 우선순위: 1순위 즐겨찾기 여부 -> 2순위 미션 타이틀명
+    // 정렬 우선순위: 1순위 즐겨찾기 여부(true/false) -> 2순위 추천 점수(최대 3개) -> 3순위 미션 타이틀명
     private func sort(_ missions: [SampleMission]) -> [SampleMission] {
         // 우선 전체 데이터를 타이틀명 기준으로 정렬
         let missions = missions.sorted { $0.title < $1.title }
         
         let favorites = state.favorites.value
         
+        // 전체 데이터를 즐겨찾기 여부에 따라 2개로 분리
         let favoriteMissions = missions.filter {
             favorites.contains($0.missionId)
         }
@@ -155,13 +160,66 @@ final class MissionListViewModel: ViewModelProtocol {
             !favorites.contains($0.missionId)
         }
         
-        // 즐겨찾기 등록된 미션을 앞으로, 나머지는 뒤로
-        return favoriteMissions + noFavoriteMissions
+        // 즐겨찾기 false 데이터 중 추천 미션 선정(최대 3개)
+        let recommendedMissions = recommend(among: noFavoriteMissions)
+        state.recommendedMissions = recommendedMissions
+        let ids = recommendedMissions.map { $0.missionId }
+        
+        // 나머지 데이터
+        let remainingMissions = noFavoriteMissions.filter {
+            !ids.contains($0.missionId)
+        }
+        
+        return favoriteMissions + recommendedMissions + remainingMissions
     }
     
     // 즐겨찾기 샘플미션 로드
     private func loadFavorites() {
-        let favorites = UserDefaults.standard.stringArray(forKey: "favorites") ?? []
+        let favorites = UserDefaults.standard.stringArray(forKey: UserDefaultsKey.favorites) ?? []
         state.favorites.accept(Set(favorites))
     }
+    
+    // 미션별 추천 점수 로드
+    private func loadMissionScores() {
+        missionScores = UserDefaults.standard.dictionary(forKey: UserDefaultsKey.missionScores) as? [String: Double] ?? [:]
+    }
+    
+    // 추천 미션 선정(최대 3개)
+    private func recommend(among missions: [SampleMission]) -> [SampleMission] {
+        let recommendedMissions = missions
+            .filter { (missionScores[$0.missionId] ?? 0) > 0 } // 점수가 0 초과인 미션만 추천(0은 추천 안함)
+            .sorted { (missionScores[$0.missionId] ?? 0) > (missionScores[$1.missionId] ?? 0) } // 점수 순 정렬
+            .prefix(3) // 상위 3개만 추출
+        return Array(recommendedMissions)
+    }
+    
+    // 미션별 추천 점수 적립
+    // 어떤 이벤트가 일어날 때, 해당 미션에 이벤트별 점수를 적립(예: 사용자가 미션 전달하기를 완료하면 해당 미션에 0.4점 부여)
+    private func donate(_ event: Event, to mission: SampleMission) {
+        var scores = missionScores
+        var score = scores[mission.missionId] ?? 0
+        
+        score += event.relevance // 이벤트별 점수를 적립
+        scores[mission.missionId] = score
+        
+        missionScores = scores
+        UserDefaults.standard.set(scores, forKey: UserDefaultsKey.missionScores)
+    }
+}
+
+enum Event {
+    case tapMission
+    case assignMission
+    
+    var relevance: Double {
+        switch self {
+        case .tapMission: 0.1
+        case .assignMission: 0.4
+        }
+    }
+}
+
+struct UserDefaultsKey {
+    static let favorites = "favorites"
+    static let missionScores = "missionScores"
 }


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-201

## 📌 변경 사항 및 이유
- 추천 미션 제안 기능 구현

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro(추천 제안되었을 때 UI) |![Simulator Screen Recording - iPhone 16 Pro - 2025-07-04 at 17 19 09](https://github.com/user-attachments/assets/a015b3cd-b3d3-444f-81b8-69a7855448d3)|
| iPhone 16 Pro(제안되는 과정: 예) 동일 미션을 2번 전달) |![Simulator Screen Recording - iPhone 16 Pro - 2025-07-04 at 17 20 50](https://github.com/user-attachments/assets/93dbda9c-4929-4f0d-99dc-274269962a80)|

## 📌 PR Point
- 추천 미션 제안 방식
- 1) 추천 점수 1.0 이상인 미션 중 상위 3개 제안(해당 카테고리별 최대 3개 제안)
- 2) 한번 탭해서 들어가면 0.1점, 미션 전달하기 버튼 누르면 0.4점 점수 적립(그래서 실제 미션 전달하기 하면 0.5점 쌓임)
- 3) 추천 점수 1.0 이하는 추천 대상에서 제외(실수로 탭하는 경우 고려)

## 📌 참고 사항
- 현재 딱히 훌륭한 방식은 아니지만, 알고리즘은 개선해 나가면 된다고 생각합니다. 더 좋은 방식 언제든 제안해 주세요. 
- 추천 결과가 실시간으로 반영되지는 않습니다(다른 화면에 갔다와야 반영됨). 실시간으로 하려 했으나 생각보다 까다로워서 보류했습니다. 실시간 반영 여부 보다는 추천 제안 로직이 더 중요하다고 생각합니다.