### PR TITLE
[Feat] STAMPIT-228 샘플 미션 코어데이터 적용

### DIFF
--- a/StampIt-Project/StampIt-Project/App/DIContainer.swift
+++ b/StampIt-Project/StampIt-Project/App/DIContainer.swift
@@ -58,10 +58,12 @@ final class DIContainer {
     }()
 
     lazy var missionRepository: MissionRepository = {
+        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
         return MissionRepositoryImpl(
             missionManager: missionManager,
             membershipManager: membershipManager,
-            authRepository: authRepository
+            authRepository: authRepository,
+            context: context
         )
     }()
 

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -56,18 +56,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             if hasOnboarded {
                 let launchVC = LaunchViewController(container: container)
                 nav = UINavigationController(rootViewController: launchVC)
+                
+                // 코어데이터에 샘플 미션 데이터가 없으면 마이그레이션 실행
+                if container.missionRepository.fetchSampleMission().isEmpty {
+                    migrateSampleMission(container: container)
+                }
             } else {
                 let onboardingVC = container.makeOnboardingViewController()
                 nav = UINavigationController(rootViewController: onboardingVC)
                 
                 // 온보딩 시 샘플 미션 JSON 데이터를 코어데이터에 저장
-                container.missionRepository.loadSampleMission()
-                    .subscribe { missions in
-                        container.missionRepository.saveAllSampleMissions(missions: missions)
-                    } onFailure: { error in
-                        print(error)
-                    }
-                    .disposed(by: disposeBag)
+                migrateSampleMission(container: container)
             }
             self.window?.rootViewController = nav
             self.window?.makeKeyAndVisible()
@@ -103,6 +102,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+    }
+    
+    // 샘플 미션 JSON 데이터를 코어데이터에 저장
+    private func migrateSampleMission(container: DIContainer) {
+        container.missionRepository.loadSampleMission()
+            .subscribe { missions in
+                container.missionRepository.saveAllSampleMissions(missions: missions)
+            } onFailure: { error in
+                print(error)
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -58,8 +58,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 nav = UINavigationController(rootViewController: launchVC)
                 
                 // 코어데이터에 샘플 미션 데이터가 없으면 마이그레이션 실행
-                if container.missionRepository.fetchSampleMission().isEmpty {
+                let missions = container.missionRepository.fetchSampleMission()
+                if missions.isEmpty {
                     migrateSampleMission(container: container)
+                    migrateFavorites(missions: missions, container: container)
                 }
             } else {
                 let onboardingVC = container.makeOnboardingViewController()
@@ -113,6 +115,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 print(error)
             }
             .disposed(by: disposeBag)
+    }
+    
+    // UserDefaults에 저장된 favorites 정보를 코어데이터로 마이그레이션
+    // 마이그레이션 완료 시 UserDefaults 삭제
+    private func migrateFavorites(missions: [SampleMission], container: DIContainer) {
+        let favorites = UserDefaults.standard.stringArray(forKey: "favorites")
+        guard let favorites, !favorites.isEmpty else { return }
+        
+        favorites.forEach { favorite in
+            let mission = missions.filter { $0.missionId == favorite }.first
+            if let mission {
+                container.missionRepository.updateSampleMission(mission: mission)
+            }
+        }
+        
+        UserDefaults.standard.removeObject(forKey: "favorites")
     }
 }
 

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -111,6 +111,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             .subscribe { [weak self] missions in
                 container.missionRepository.saveAllSampleMissions(missions: missions)
                 self?.migrateFavorites(container: container)
+                self?.migrateMissionScores(container: container)
             } onFailure: { error in
                 print(error)
             }
@@ -134,6 +135,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         UserDefaults.standard.removeObject(forKey: "favorites")
+    }
+    
+    // UserDefaults에 저장된 mission score 정보를 코어데이터로 마이그레이션
+    // 마이그레이션 완료 시 UserDefaults 삭제
+    private func migrateMissionScores(container: DIContainer) {
+        let scores = UserDefaults.standard.dictionary(forKey: "missionScores") as? [String: Double]
+        guard let scores, !scores.isEmpty else { return }
+        let missions = container.missionRepository.fetchSampleMission()
+        guard !missions.isEmpty else { return }
+        
+        scores.forEach { score in
+            let mission = missions.filter { $0.missionId == score.key }.first
+            if var mission {
+                mission.score = score.value
+                container.missionRepository.updateSampleMission(mission: mission)
+            }
+        }
+        
+        UserDefaults.standard.removeObject(forKey: "missionScores")
     }
 }
 

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -61,7 +61,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 let missions = container.missionRepository.fetchSampleMission()
                 if missions.isEmpty {
                     migrateSampleMission(container: container)
-                    migrateFavorites(missions: missions, container: container)
                 }
             } else {
                 let onboardingVC = container.makeOnboardingViewController()
@@ -109,8 +108,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // 샘플 미션 JSON 데이터를 코어데이터에 저장
     private func migrateSampleMission(container: DIContainer) {
         container.missionRepository.loadSampleMission()
-            .subscribe { missions in
+            .subscribe { [weak self] missions in
                 container.missionRepository.saveAllSampleMissions(missions: missions)
+                self?.migrateFavorites(container: container)
             } onFailure: { error in
                 print(error)
             }
@@ -119,13 +119,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     // UserDefaults에 저장된 favorites 정보를 코어데이터로 마이그레이션
     // 마이그레이션 완료 시 UserDefaults 삭제
-    private func migrateFavorites(missions: [SampleMission], container: DIContainer) {
+    private func migrateFavorites(container: DIContainer) {
         let favorites = UserDefaults.standard.stringArray(forKey: "favorites")
         guard let favorites, !favorites.isEmpty else { return }
+        let missions = container.missionRepository.fetchSampleMission()
+        guard !missions.isEmpty else { return }
         
         favorites.forEach { favorite in
             let mission = missions.filter { $0.missionId == favorite }.first
-            if let mission {
+            if var mission {
+                mission.isFavorite = true
                 container.missionRepository.updateSampleMission(mission: mission)
             }
         }

--- a/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
+++ b/StampIt-Project/StampIt-Project/App/SceneDelegate.swift
@@ -6,11 +6,13 @@
 //
 
 import UIKit
+import RxSwift
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     
+    private let disposeBag = DisposeBag()
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
@@ -57,6 +59,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             } else {
                 let onboardingVC = container.makeOnboardingViewController()
                 nav = UINavigationController(rootViewController: onboardingVC)
+                
+                // 온보딩 시 샘플 미션 JSON 데이터를 코어데이터에 저장
+                container.missionRepository.loadSampleMission()
+                    .subscribe { missions in
+                        container.missionRepository.saveAllSampleMissions(missions: missions)
+                    } onFailure: { error in
+                        print(error)
+                    }
+                    .disposed(by: disposeBag)
             }
             self.window?.rootViewController = nav
             self.window?.makeKeyAndVisible()

--- a/StampIt-Project/StampIt-Project/Data/CoreData/SampleMissionEntity+CoreDataClass.swift
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/SampleMissionEntity+CoreDataClass.swift
@@ -1,0 +1,17 @@
+//
+//  SampleMissionEntity+CoreDataClass.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 7/19/25.
+//
+//
+
+public import Foundation
+public import CoreData
+
+public typealias SampleMissionEntityCoreDataClassSet = NSSet
+
+@objc(SampleMissionEntity)
+public class SampleMissionEntity: NSManagedObject {
+    static let entityName = "SampleMissionEntity"
+}

--- a/StampIt-Project/StampIt-Project/Data/CoreData/SampleMissionEntity+CoreDataProperties.swift
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/SampleMissionEntity+CoreDataProperties.swift
@@ -22,6 +22,8 @@ extension SampleMissionEntity {
     @NSManaged public var isFavorite: Bool
     @NSManaged public var missionId: String?
     @NSManaged public var title: String?
+    @NSManaged public var score: Double
+    @NSManaged public var timestamp: Date
 
     var category: MissionCategory {
         get {

--- a/StampIt-Project/StampIt-Project/Data/CoreData/SampleMissionEntity+CoreDataProperties.swift
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/SampleMissionEntity+CoreDataProperties.swift
@@ -1,0 +1,38 @@
+//
+//  SampleMissionEntity+CoreDataProperties.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 7/19/25.
+//
+//
+
+public import Foundation
+public import CoreData
+
+
+public typealias SampleMissionEntityCoreDataPropertiesSet = NSSet
+
+extension SampleMissionEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<SampleMissionEntity> {
+        return NSFetchRequest<SampleMissionEntity>(entityName: SampleMissionEntity.entityName)
+    }
+
+    @NSManaged public var categoryRaw: String
+    @NSManaged public var isFavorite: Bool
+    @NSManaged public var missionId: String?
+    @NSManaged public var title: String?
+
+    var category: MissionCategory {
+        get {
+            MissionCategory(rawValue: categoryRaw) ?? .chore
+        }
+        set {
+            categoryRaw = newValue.rawValue
+        }
+    }
+}
+
+extension SampleMissionEntity : Identifiable {
+
+}

--- a/StampIt-Project/StampIt-Project/Data/CoreData/StampIt_Project.xcdatamodeld/StampIt_Project.xcdatamodel/contents
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/StampIt_Project.xcdatamodeld/StampIt_Project.xcdatamodel/contents
@@ -4,6 +4,8 @@
         <attribute name="categoryRaw" attributeType="String"/>
         <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="missionId" optional="YES" attributeType="String"/>
+        <attribute name="score" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="title" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/StampIt-Project/StampIt-Project/Data/CoreData/StampIt_Project.xcdatamodeld/StampIt_Project.xcdatamodel/contents
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/StampIt_Project.xcdatamodeld/StampIt_Project.xcdatamodel/contents
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24270" systemVersion="25A5306g" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="SampleMissionEntity" representedClassName="SampleMissionEntity" syncable="YES">
+        <attribute name="categoryRaw" attributeType="String"/>
+        <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="missionId" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
 </model>

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -8,20 +8,24 @@
 import Foundation
 import RxSwift
 import FirebaseCore
+import CoreData
 
 final class MissionRepositoryImpl: MissionRepository {
     private let missionManager: any MissionManagerProtocol
     private let membershipManager: any MembershipManagerProtocol
     private let authRepository: any AuthRepositoryProtocol
+    private let context: NSManagedObjectContext
     
     init(
         missionManager: any MissionManagerProtocol,
         membershipManager: any MembershipManagerProtocol,
-        authRepository: any AuthRepositoryProtocol
+        authRepository: any AuthRepositoryProtocol,
+        context: NSManagedObjectContext
     ) {
         self.missionManager = missionManager
         self.membershipManager = membershipManager
         self.authRepository = authRepository
+        self.context = context
     }
     
     // 샘플 미션 데이터 로드
@@ -127,5 +131,49 @@ final class MissionRepositoryImpl: MissionRepository {
     // 미션 1개 패치
     func fetchMission(widh id: String) -> Observable<Mission?> {
         missionManager.fetch(id: id).map { $0?.toDomainModel() }
+    }
+    
+    // 샘플 미션 전체를 코어데이터에 저장
+    func saveAllSampleMissions(missions: [SampleMission]) {
+        missions.forEach {
+            saveSampleMission(missionId: $0.missionId,
+                              title: $0.title,
+                              category: $0.category,
+                              isFavorite: $0.isFavorite)
+        }
+    }
+    
+    // 샘플 미션을 코어데이터에 저장
+    private func saveSampleMission(missionId: String, title: String, category: MissionCategory, isFavorite: Bool = false) {
+        let mission = SampleMissionEntity(context: context)
+        mission.missionId = missionId
+        mission.title = title
+        mission.category = category
+        mission.isFavorite = isFavorite
+        
+        do {
+            try context.save()
+        } catch {
+            print("Failed to save Core Data changes: \(error)")
+        }
+    }
+    
+    // 코어데이터 샘플 미션을 패치
+    func fetchSampleMission() -> [SampleMission] {
+        let fetchRequest: NSFetchRequest<SampleMissionEntity> = SampleMissionEntity.fetchRequest()
+        
+        do {
+            let missions = try context.fetch(fetchRequest)
+            return missions.map { mission in
+                return SampleMission(missionId: mission.missionId ?? "",
+                                     title: mission.title ?? "",
+                                     description: nil,
+                                     category: mission.category,
+                                     isFavorite: mission.isFavorite)
+            }
+        } catch {
+            print("Failed to fetch Core Data: \(error)")
+            return []
+        }
     }
 }

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -183,6 +183,30 @@ final class MissionRepositoryImpl: MissionRepository {
         }
     }
     
+    // 코어데이터 특정 샘플 미션을 패치
+    func fetchSampleMission(withId missionId: String) -> [SampleMission] {
+        let fetchRequest: NSFetchRequest<SampleMissionEntity> = SampleMissionEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "missionId == %@", missionId)
+        
+        do {
+            let missions = try context.fetch(fetchRequest)
+            guard !missions.isEmpty else { return [] }
+            
+            return missions.map { mission in
+                return SampleMission(missionId: mission.missionId ?? "",
+                                     title: mission.title ?? "",
+                                     description: nil,
+                                     category: mission.category,
+                                     isFavorite: mission.isFavorite,
+                                     score: mission.score,
+                                     timestamp: mission.timestamp)
+            }
+        } catch {
+            print("Failed to fetch Core Data: \(error)")
+            return []
+        }
+    }
+    
     // 코어데이터 샘플 미션 업데이트
     func updateSampleMission(mission: SampleMission) {
         let fetchRequest: NSFetchRequest<SampleMissionEntity> = SampleMissionEntity.fetchRequest()

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -139,17 +139,21 @@ final class MissionRepositoryImpl: MissionRepository {
             saveSampleMission(missionId: $0.missionId,
                               title: $0.title,
                               category: $0.category,
-                              isFavorite: $0.isFavorite)
+                              isFavorite: $0.isFavorite,
+                              score: $0.score,
+                              timestamp: $0.timestamp)
         }
     }
     
     // 샘플 미션을 코어데이터에 저장
-    private func saveSampleMission(missionId: String, title: String, category: MissionCategory, isFavorite: Bool = false) {
+    private func saveSampleMission(missionId: String, title: String, category: MissionCategory, isFavorite: Bool = false, score: Double = 0.0, timestamp: Date = .now) {
         let mission = SampleMissionEntity(context: context)
         mission.missionId = missionId
         mission.title = title
         mission.category = category
         mission.isFavorite = isFavorite
+        mission.score = score
+        mission.timestamp = timestamp
         
         do {
             try context.save()
@@ -169,7 +173,9 @@ final class MissionRepositoryImpl: MissionRepository {
                                      title: mission.title ?? "",
                                      description: nil,
                                      category: mission.category,
-                                     isFavorite: mission.isFavorite)
+                                     isFavorite: mission.isFavorite,
+                                     score: mission.score,
+                                     timestamp: mission.timestamp)
             }
         } catch {
             print("Failed to fetch Core Data: \(error)")
@@ -188,6 +194,10 @@ final class MissionRepositoryImpl: MissionRepository {
             
             missions.forEach {
                 $0.isFavorite = mission.isFavorite
+                if $0.score != mission.score {
+                    $0.score = mission.score
+                    $0.timestamp = mission.timestamp // score가 변경되면 timestamp도 변경
+                }
             }
             
             try context.save()

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -176,4 +176,23 @@ final class MissionRepositoryImpl: MissionRepository {
             return []
         }
     }
+    
+    // 코어데이터 샘플 미션 업데이트
+    func updateSampleMission(mission: SampleMission) {
+        let fetchRequest: NSFetchRequest<SampleMissionEntity> = SampleMissionEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "missionId == %@", mission.missionId)
+        
+        do {
+            let missions = try context.fetch(fetchRequest)
+            guard !missions.isEmpty else { return }
+            
+            missions.forEach {
+                $0.isFavorite = mission.isFavorite
+            }
+            
+            try context.save()
+        } catch {
+            print("Failed to fetch or save Core Data recentBook: \(error)")
+        }
+    }
 }

--- a/StampIt-Project/StampIt-Project/Domain/Entities/SampleMission.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/SampleMission.swift
@@ -12,6 +12,7 @@ struct SampleMission: Decodable {
     let title: String
     let description: String?
     let category: MissionCategory
+    var isFavorite: Bool = false
     
     enum CodingKeys: String, CodingKey {
         case missionId, title, description, category
@@ -39,10 +40,11 @@ struct SampleMission: Decodable {
         }
     }
     
-    init(missionId: String, title: String, description: String?, category: MissionCategory) {
+    init(missionId: String, title: String, description: String?, category: MissionCategory, isFavorite: Bool = false) {
         self.missionId = missionId
         self.title = title
         self.description = description
         self.category = category
+        self.isFavorite = isFavorite
     }
 }

--- a/StampIt-Project/StampIt-Project/Domain/Entities/SampleMission.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/SampleMission.swift
@@ -13,6 +13,8 @@ struct SampleMission: Decodable {
     let description: String?
     let category: MissionCategory
     var isFavorite: Bool = false
+    var score: Double = 0.0
+    var timestamp: Date = .now
     
     enum CodingKeys: String, CodingKey {
         case missionId, title, description, category
@@ -40,11 +42,13 @@ struct SampleMission: Decodable {
         }
     }
     
-    init(missionId: String, title: String, description: String?, category: MissionCategory, isFavorite: Bool = false) {
+    init(missionId: String, title: String, description: String?, category: MissionCategory, isFavorite: Bool = false, score: Double = 0.0, timestamp: Date = .now) {
         self.missionId = missionId
         self.title = title
         self.description = description
         self.category = category
         self.isFavorite = isFavorite
+        self.score = score
+        self.timestamp = timestamp
     }
 }

--- a/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
@@ -42,4 +42,8 @@ protocol MissionRepository {
     /// 코어데이터 샘플 미션을 패치
     /// - Returns: 샘플 미션 데이터
     func fetchSampleMission() -> [SampleMission]
+    
+    /// 코어데이터 샘플 미션 업데이트
+    /// - Parameter mission: 샘플 미션 데이터
+    func updateSampleMission(mission: SampleMission)
 }

--- a/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
@@ -43,6 +43,11 @@ protocol MissionRepository {
     /// - Returns: 샘플 미션 데이터
     func fetchSampleMission() -> [SampleMission]
     
+    /// 코어데이터 특정 샘플 미션을 패치
+    /// - Parameter missionId: 미션 ID
+    /// - Returns: 샘플 미션 데이터
+    func fetchSampleMission(withId missionId: String) -> [SampleMission]
+    
     /// 코어데이터 샘플 미션 업데이트
     /// - Parameter mission: 샘플 미션 데이터
     func updateSampleMission(mission: SampleMission)

--- a/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
@@ -34,4 +34,12 @@ protocol MissionRepository {
     ///   - id: 미션 ID
     /// - Returns: 미션 1개
     func fetchMission(widh id: String) -> Observable<Mission?>
+    
+    /// 샘플 미션 전체를 코어데이터에 저장
+    /// - Parameter missions: 샘플 미션 데이터
+    func saveAllSampleMissions(missions: [SampleMission])
+    
+    /// 코어데이터 샘플 미션을 패치
+    /// - Returns: 샘플 미션 데이터
+    func fetchSampleMission() -> [SampleMission]
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
@@ -34,4 +34,8 @@ protocol MissionUseCase {
     ///   - id: 미션 ID
     /// - Returns: 미션 1개
     func fetchMission(with id: String) -> Observable<MissionUI?>
+    
+    /// 코어데이터 샘플 미션을 패치
+    /// - Returns: 샘플 미션 데이터
+    func fetchSampleMission() -> [SampleMission]
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
@@ -38,4 +38,8 @@ protocol MissionUseCase {
     /// 코어데이터 샘플 미션을 패치
     /// - Returns: 샘플 미션 데이터
     func fetchSampleMission() -> [SampleMission]
+    
+    /// 코어데이터 샘플 미션 업데이트
+    /// - Parameter mission: 샘플 미션 데이터
+    func updateSampleMission(mission: SampleMission)
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
@@ -39,6 +39,11 @@ protocol MissionUseCase {
     /// - Returns: 샘플 미션 데이터
     func fetchSampleMission() -> [SampleMission]
     
+    /// 코어데이터 특정 샘플 미션을 패치
+    /// - Parameter missionId: 미션 ID
+    /// - Returns: 샘플 미션 데이터
+    func fetchSampleMission(withId missionId: String) -> [SampleMission]
+    
     /// 코어데이터 샘플 미션 업데이트
     /// - Parameter mission: 샘플 미션 데이터
     func updateSampleMission(mission: SampleMission)

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
@@ -41,4 +41,8 @@ struct MissionUseCaseImpl: MissionUseCase {
             .map { $0?.toPresentation() }
     }
     
+    // 코어데이터 샘플 미션을 패치
+    func fetchSampleMission() -> [SampleMission] {
+        missionRepositoryImpl.fetchSampleMission()
+    }
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
@@ -46,6 +46,11 @@ struct MissionUseCaseImpl: MissionUseCase {
         missionRepositoryImpl.fetchSampleMission()
     }
     
+    // 코어데이터 특정 샘플 미션을 패치
+    func fetchSampleMission(withId missionId: String) -> [SampleMission] {
+        missionRepositoryImpl.fetchSampleMission(withId: missionId)
+    }
+    
     // 코어데이터 샘플 미션 업데이트
     func updateSampleMission(mission: SampleMission) {
         missionRepositoryImpl.updateSampleMission(mission: mission)

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
@@ -45,4 +45,9 @@ struct MissionUseCaseImpl: MissionUseCase {
     func fetchSampleMission() -> [SampleMission] {
         missionRepositoryImpl.fetchSampleMission()
     }
+    
+    // 코어데이터 샘플 미션 업데이트
+    func updateSampleMission(mission: SampleMission) {
+        missionRepositoryImpl.updateSampleMission(mission: mission)
+    }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -141,16 +141,14 @@ final class MissionListViewController: UIViewController {
             .drive(tableView.rx.items(cellIdentifier: MissionListCell.reuseIdentifier, cellType: MissionListCell.self)) { [weak self] (_, element, cell) in
                 guard let self else { return }
                 
-                let favorites = viewModel.state.favorites.value
                 let isOnlyFavorites = viewModel.state.isOnlyFavorite.value
                 let recommendedMissions = viewModel.state.recommendedMissions
-                let isFavorite = favorites.contains(element.missionId)
                 let isRecommended = recommendedMissions.contains(where: { $0.missionId == element.missionId })
                 
                 if isOnlyFavorites { // "즐겨찾기" 카테고리 선택하면 즐겨찾기/추천 표시 안함
                     cell.configure(with: element.title, isFavorite: false, isRecommended: false)
                 } else { // 나머지 카테고리는 즐겨찾기/추천 표시함(둘다 true면 즐겨찾기만 표시)
-                    cell.configure(with: element.title, isFavorite: isFavorite, isRecommended: isRecommended)
+                    cell.configure(with: element.title, isFavorite: element.isFavorite, isRecommended: isRecommended)
                 }
             }
             .disposed(by: disposeBag)
@@ -194,7 +192,7 @@ final class MissionListViewController: UIViewController {
                 guard let self else { return }
                 
                 let isOnlyFavorites = viewModel.state.isOnlyFavorite.value
-                let favorites = viewModel.state.favorites.value
+                let favorites = viewModel.state.missions.value.filter({ $0.isFavorite })
                 
                 if isOnlyFavorites, favorites.isEmpty {
                     noResultsView.configureContent(title: "즐겨찾기가 없어요", description: "미션을 스와이프해서 즐겨찾기에 추가하세요")

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -22,7 +22,6 @@ final class MissionListViewModel: ViewModelProtocol {
         var missions = BehaviorRelay<[SampleMission]>(value: []) // 뷰에 반영되는 샘플 미션 데이터
         var searchText = BehaviorRelay<String>(value: "")
         var selectedCategory = BehaviorRelay<MissionCategory?>(value: nil)
-        var favorites = BehaviorRelay<Set<String>>(value: [])
         var isOnlyFavorite = BehaviorRelay<Bool>(value: false) // 즐겨찾기 등록된 미션만 보여줘야 하는지 true/false
         var recommendedMissions: [SampleMission] = []
     }
@@ -33,7 +32,7 @@ final class MissionListViewModel: ViewModelProtocol {
     var disposeBag = DisposeBag()
     
     private let missionUseCaseImpl: MissionUseCase
-    private var _missions: [SampleMission] = [] // 샘플 미션 JSON 원본 데이터
+    private var _missions: [SampleMission] = [] // 샘플 미션 원본 데이터
     private var missionScores: [String: Double] = [:] // 미션별 추천 점수
     
     init(missionUseCaseImpl: MissionUseCase) {
@@ -43,7 +42,6 @@ final class MissionListViewModel: ViewModelProtocol {
         
         bindFilterMisson()
         
-        loadFavorites()
         loadMissionScores()
     }
     
@@ -81,16 +79,12 @@ final class MissionListViewModel: ViewModelProtocol {
                     }
                 case .toggleFavorite(let indexPath):
                     let mission = state.missions.value[indexPath.row]
-                    var favorites = state.favorites.value
+                    guard let missionIndex = _missions.firstIndex(where: { $0.missionId == mission.missionId }) else { return }
                     
-                    // 토글 형식이므로, 현재 즐겨찾기인 미션을 탭하면 즐겨찾기 해제, 현재 즐겨찾기가 아닌 미션을 탭하면 즐겨찾기 등록
-                    if favorites.contains(mission.missionId) {
-                        favorites.remove(mission.missionId)
-                    } else {
-                        favorites.insert(mission.missionId)
-                    }
-                    state.favorites.accept(favorites)
-                    UserDefaults.standard.set(Array(favorites), forKey: UserDefaultsKey.favorites)
+                    _missions[missionIndex].isFavorite.toggle()
+                    missionUseCaseImpl.updateSampleMission(mission: _missions[missionIndex])
+                    
+                    state.searchText.accept(state.searchText.value) // 뷰 업데이트 트리거
                 }
             }
             .disposed(by: disposeBag)
@@ -98,8 +92,8 @@ final class MissionListViewModel: ViewModelProtocol {
     
     // 미션 검색 + 카테고리 선택
     private func bindFilterMisson() {
-        Observable.combineLatest(state.searchText, state.selectedCategory, state.isOnlyFavorite, state.favorites)
-            .map { [weak self] searchText, selectedCategory, isOnlyFavorite, favorites -> [SampleMission] in
+        Observable.combineLatest(state.searchText, state.selectedCategory, state.isOnlyFavorite)
+            .map { [weak self] searchText, selectedCategory, isOnlyFavorite -> [SampleMission] in
                 guard let self else { return [] }
                 
                 // 단어 단위로 분할
@@ -110,7 +104,7 @@ final class MissionListViewModel: ViewModelProtocol {
                 
                 let filteredMissions = _missions.filter { mission in
                     // 즐겨찾기 필터
-                    if isOnlyFavorite, !favorites.contains(mission.missionId) {
+                    if isOnlyFavorite, !mission.isFavorite {
                         return false
                     }
                     
@@ -142,15 +136,13 @@ final class MissionListViewModel: ViewModelProtocol {
         // 우선 전체 데이터를 타이틀명 기준으로 정렬
         let missions = missions.sorted { $0.title < $1.title }
         
-        let favorites = state.favorites.value
-        
         // 전체 데이터를 즐겨찾기 여부에 따라 2개로 분리
         let favoriteMissions = missions.filter {
-            favorites.contains($0.missionId)
+            $0.isFavorite
         }
         
         let noFavoriteMissions = missions.filter {
-            !favorites.contains($0.missionId)
+            !$0.isFavorite
         }
         
         // 즐겨찾기 false 데이터 중 추천 미션 선정(최대 3개)
@@ -164,12 +156,6 @@ final class MissionListViewModel: ViewModelProtocol {
         }
         
         return favoriteMissions + recommendedMissions + remainingMissions
-    }
-    
-    // 즐겨찾기 샘플미션 로드
-    private func loadFavorites() {
-        let favorites = UserDefaults.standard.stringArray(forKey: UserDefaultsKey.favorites) ?? []
-        state.favorites.accept(Set(favorites))
     }
     
     // 미션별 추천 점수 로드
@@ -202,7 +188,6 @@ final class MissionListViewModel: ViewModelProtocol {
 
 extension MissionListViewModel {
     struct UserDefaultsKey {
-        static let favorites = "favorites"
         static let missionScores = "missionScores"
     }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -54,17 +54,10 @@ final class MissionListViewModel: ViewModelProtocol {
                 
                 switch input {
                 case .onAppear:
-                    missionUseCaseImpl.loadSampleMission()
-                        .subscribe { [weak self] missions in
-                            guard let self else { return }
-                            
-                            let sortedMissions = sort(missions)
-                            state.missions.accept(sortedMissions)
-                            _missions = sortedMissions
-                        } onFailure: { error in
-                            print(error)
-                        }
-                        .disposed(by: disposeBag)
+                    let missions = missionUseCaseImpl.fetchSampleMission()
+                    let sortedMissions = sort(missions)
+                    state.missions.accept(sortedMissions)
+                    _missions = sortedMissions
                 case .searchTextChanged(let searchText):
                     state.searchText.accept(searchText)
                     print("searchText: \(searchText)")

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/MissionListViewModel.swift
@@ -33,7 +33,6 @@ final class MissionListViewModel: ViewModelProtocol {
     
     private let missionUseCaseImpl: MissionUseCase
     private var _missions: [SampleMission] = [] // 샘플 미션 원본 데이터
-    private var missionScores: [String: Double] = [:] // 미션별 추천 점수
     
     init(missionUseCaseImpl: MissionUseCase) {
         self.missionUseCaseImpl = missionUseCaseImpl
@@ -41,8 +40,6 @@ final class MissionListViewModel: ViewModelProtocol {
         bind()
         
         bindFilterMisson()
-        
-        loadMissionScores()
     }
     
     private func bind() {
@@ -158,16 +155,11 @@ final class MissionListViewModel: ViewModelProtocol {
         return favoriteMissions + recommendedMissions + remainingMissions
     }
     
-    // 미션별 추천 점수 로드
-    private func loadMissionScores() {
-        missionScores = UserDefaults.standard.dictionary(forKey: UserDefaultsKey.missionScores) as? [String: Double] ?? [:]
-    }
-    
     // 추천 미션 선정(최대 3개)
     private func recommend(among missions: [SampleMission]) -> [SampleMission] {
         let recommendedMissions = missions
-            .filter { (missionScores[$0.missionId] ?? 0) >= 1.0 } // 점수가 1.0 이상인 미션만 추천
-            .sorted { (missionScores[$0.missionId] ?? 0) > (missionScores[$1.missionId] ?? 0) } // 점수 순 정렬
+            .filter { $0.score >= 1.0 } // 점수가 1.0 이상인 미션만 추천
+            .sorted { $0.score > $1.score } // 점수 순 정렬
             .prefix(3) // 상위 3개만 추출
         return Array(recommendedMissions)
     }
@@ -175,19 +167,10 @@ final class MissionListViewModel: ViewModelProtocol {
     // 미션별 추천 점수 적립
     // 어떤 이벤트가 일어날 때, 해당 미션에 이벤트별 점수를 적립(예: 사용자가 미션 전달하기를 완료하면 해당 미션에 0.4점 부여)
     func donate(_ event: Event, to mission: SampleMission) {
-        var scores = missionScores
-        var score = scores[mission.missionId] ?? 0
+        guard var mission = missionUseCaseImpl.fetchSampleMission(withId: mission.missionId).first else { return }
         
-        score += event.relevance // 이벤트별 점수를 적립
-        scores[mission.missionId] = score
+        mission.score += event.relevance // 이벤트별 점수를 적립
         
-        missionScores = scores
-        UserDefaults.standard.set(scores, forKey: UserDefaultsKey.missionScores)
-    }
-}
-
-extension MissionListViewModel {
-    struct UserDefaultsKey {
-        static let missionScores = "missionScores"
+        missionUseCaseImpl.updateSampleMission(mission: mission)
     }
 }

--- a/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
+++ b/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
@@ -169,4 +169,9 @@ final class MissionRepositoryTest: MissionRepository {
     // 코어데이터 샘플 미션 업데이트
     func updateSampleMission(mission: SampleMission) {
     }
+    
+    // 코어데이터 특정 샘플 미션 업데이트
+    func fetchSampleMission(withId missionId: String) -> [SampleMission] {
+        return []
+    }
 }

--- a/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
+++ b/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
@@ -165,4 +165,8 @@ final class MissionRepositoryTest: MissionRepository {
     func fetchSampleMission() -> [SampleMission] {
         return []
     }
+    
+    // 코어데이터 샘플 미션 업데이트
+    func updateSampleMission(mission: SampleMission) {
+    }
 }

--- a/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
+++ b/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
@@ -156,4 +156,13 @@ final class MissionRepositoryTest: MissionRepository {
     func fetchMission(widh id: String) -> Observable<Mission?> {
         missionManager.fetch(id: id).map { $0?.toDomainModel() }
     }
+    
+    // 샘플 미션 전체를 코어데이터에 저장
+    func saveAllSampleMissions(missions: [SampleMission]) {
+    }
+    
+    // 코어데이터 샘플 미션을 패치
+    func fetchSampleMission() -> [SampleMission] {
+        return []
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-228

## 📌 변경 사항 및 이유
- 최초 앱 실행 시 JSON 데이터 -> 코어데이터 마이그레이션
- 즐겨찾기 정보 user defaults -> 코어데이터
- 미션 추천점수 정보 user defaults -> 코어데이터
- 기존 앱 사용자의 즐겨찾기 및 미션 추천점수 정보도 그대로 마이그레이션

## 📌 구현 내역 스크린샷
생략

## 📌 PR Point
없음

## 📌 참고 사항
기능 상 변동사항은 없습니다.