### PR TITLE
[Feat] STAMPIT-240 - 코어데이터 엔티티 추가(사용자가 전달한 미션정보를 저장)

### DIFF
--- a/StampIt-Project/StampIt-Project/Data/CoreData/MissionDataEntity+CoreDataClass.swift
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/MissionDataEntity+CoreDataClass.swift
@@ -1,0 +1,17 @@
+//
+//  MissionDataEntity+CoreDataClass.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 8/3/25.
+//
+//
+
+public import Foundation
+public import CoreData
+
+public typealias MissionDataEntityCoreDataClassSet = NSSet
+
+@objc(MissionDataEntity)
+public class MissionDataEntity: NSManagedObject {
+    static let entityName = "MissionDataEntity"
+}

--- a/StampIt-Project/StampIt-Project/Data/CoreData/MissionDataEntity+CoreDataProperties.swift
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/MissionDataEntity+CoreDataProperties.swift
@@ -1,0 +1,40 @@
+//
+//  MissionDataEntity+CoreDataProperties.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 8/3/25.
+//
+//
+
+public import Foundation
+public import CoreData
+
+
+public typealias MissionDataEntityCoreDataPropertiesSet = NSSet
+
+extension MissionDataEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<MissionDataEntity> {
+        return NSFetchRequest<MissionDataEntity>(entityName: MissionDataEntity.entityName)
+    }
+
+    @NSManaged public var title: String?
+    @NSManaged public var assigneeId: String?
+    @NSManaged public var assigneeNickname: String?
+    @NSManaged public var createDate: Date?
+    @NSManaged public var dueDate: Date?
+    @NSManaged public var categoryRaw: String
+    
+    var category: MissionCategory {
+        get {
+            MissionCategory(rawValue: categoryRaw) ?? .chore
+        }
+        set {
+            categoryRaw = newValue.rawValue
+        }
+    }
+}
+
+extension MissionDataEntity : Identifiable {
+
+}

--- a/StampIt-Project/StampIt-Project/Data/CoreData/StampIt_Project.xcdatamodeld/StampIt_Project.xcdatamodel/contents
+++ b/StampIt-Project/StampIt-Project/Data/CoreData/StampIt_Project.xcdatamodeld/StampIt_Project.xcdatamodel/contents
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24270" systemVersion="25A5306g" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24270" systemVersion="25A5316i" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="MissionDataEntity" representedClassName="MissionDataEntity" syncable="YES">
+        <attribute name="assigneeId" optional="YES" attributeType="String"/>
+        <attribute name="assigneeNickname" optional="YES" attributeType="String"/>
+        <attribute name="categoryRaw" attributeType="String"/>
+        <attribute name="createDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dueDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="SampleMissionEntity" representedClassName="SampleMissionEntity" syncable="YES">
         <attribute name="categoryRaw" attributeType="String"/>
         <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
+++ b/StampIt-Project/StampIt-Project/Data/RepositoryImpl/MissionRepositoryImpl.swift
@@ -229,4 +229,41 @@ final class MissionRepositoryImpl: MissionRepository {
             print("Failed to fetch or save Core Data recentBook: \(error)")
         }
     }
+    
+    // 전달한 미션 정보를 코어데이터에 저장
+    func saveMissionData(title: String, assigneeId: String, assigneeNickname: String, createDate: Date, dueDate: Date, category: MissionCategory) {
+        let mission = MissionDataEntity(context: context)
+        mission.title = title
+        mission.assigneeId = assigneeId
+        mission.assigneeNickname = assigneeNickname
+        mission.createDate = createDate
+        mission.dueDate = dueDate
+        mission.category = category
+        
+        do {
+            try context.save()
+        } catch {
+            print("Failed to save Core Data changes: \(error)")
+        }
+    }
+    
+    // 코어데이터 미션 데이터를 패치
+    func fetchMissionData() -> [MissionData] {
+        let fetchRequest: NSFetchRequest<MissionDataEntity> = MissionDataEntity.fetchRequest()
+        
+        do {
+            let missions = try context.fetch(fetchRequest)
+            return missions.map { mission in
+                return MissionData(title: mission.title ?? "",
+                                   assigneeId: mission.assigneeId ?? "",
+                                   assigneeNickname: mission.assigneeNickname ?? "",
+                                   createDate: mission.createDate ?? .now,
+                                   dueDate: mission.dueDate ?? .now,
+                                   category: mission.category)
+            }
+        } catch {
+            print("Failed to fetch Core Data: \(error)")
+            return []
+        }
+    }
 }

--- a/StampIt-Project/StampIt-Project/Domain/Entities/MissionData.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/MissionData.swift
@@ -1,0 +1,17 @@
+//
+//  MissionData.swift
+//  StampIt-Project
+//
+//  Created by 권순욱 on 8/3/25.
+//
+
+import Foundation
+
+struct MissionData {
+    let title: String
+    let assigneeId: String
+    let assigneeNickname: String
+    let createDate: Date
+    let dueDate: Date
+    let category: MissionCategory
+}

--- a/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Repository/MissionRepository.swift
@@ -51,4 +51,18 @@ protocol MissionRepository {
     /// 코어데이터 샘플 미션 업데이트
     /// - Parameter mission: 샘플 미션 데이터
     func updateSampleMission(mission: SampleMission)
+    
+    /// 전달한 미션 정보를 코어데이터에 저장
+    /// - Parameters:
+    ///   - title: 미션 타이틀
+    ///   - assigneeId: 미션을 받는 멤버 ID
+    ///   - assigneeNickname: 미션을 받는 멤버 닉네임
+    ///   - createDate: 미션 생성일자
+    ///   - dueDate: 미션 기한
+    ///   - category: 미션 카테고리
+    func saveMissionData(title: String, assigneeId: String, assigneeNickname: String, createDate: Date, dueDate: Date, category: MissionCategory)
+    
+    /// 코어데이터 미션 데이터를 패치
+    /// - Returns: 미션 데이터
+    func fetchMissionData() -> [MissionData]
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCase/MissionUseCase.swift
@@ -47,4 +47,18 @@ protocol MissionUseCase {
     /// 코어데이터 샘플 미션 업데이트
     /// - Parameter mission: 샘플 미션 데이터
     func updateSampleMission(mission: SampleMission)
+    
+    /// 전달한 미션 정보를 코어데이터에 저장
+    /// - Parameters:
+    ///   - title: 미션 타이틀
+    ///   - assigneeId: 미션을 받는 멤버 ID
+    ///   - assigneeNickname: 미션을 받는 멤버 닉네임
+    ///   - createDate: 미션 생성일자
+    ///   - dueDate: 미션 기한
+    ///   - category: 미션 카테고리
+    func saveMissionData(title: String, assigneeId: String, assigneeNickname: String, createDate: Date, dueDate: Date, category: MissionCategory)
+    
+    /// 코어데이터 미션 데이터를 패치
+    /// - Returns: 미션 데이터
+    func fetchMissionData() -> [MissionData]
 }

--- a/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
+++ b/StampIt-Project/StampIt-Project/Domain/UseCaseImpl/MissionUseCaseImpl.swift
@@ -55,4 +55,14 @@ struct MissionUseCaseImpl: MissionUseCase {
     func updateSampleMission(mission: SampleMission) {
         missionRepositoryImpl.updateSampleMission(mission: mission)
     }
+    
+    // 전달한 미션 정보를 코어데이터에 저장
+    func saveMissionData(title: String, assigneeId: String, assigneeNickname: String, createDate: Date, dueDate: Date, category: MissionCategory) {
+        missionRepositoryImpl.saveMissionData(title: title, assigneeId: assigneeId, assigneeNickname: assigneeNickname, createDate: createDate, dueDate: dueDate, category: category)
+    }
+    
+    // 코어데이터 미션 데이터를 패치
+    func fetchMissionData() -> [MissionData] {
+        missionRepositoryImpl.fetchMissionData()
+    }
 }

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/ViewModel/AssignMissionViewModel.swift
@@ -155,17 +155,22 @@ final class AssignMissionViewModel: ViewModelProtocol {
         }
         
         let title = state.customMissionTitle.value ?? state.mission.value!.title
+        let createDate = Date()
+        let category = state.mission.value!.category
         
         let mission = Mission(
             missionID: UUID().uuidString,
             title: title,
             assignedTo: member.userID,
             assignedBy: user.userID,
-            createDate: Date(),
+            createDate: createDate,
             dueDate: dueDate,
             status: MissionStatus.assigned,
             imageURL: "",
-            category: state.mission.value!.category)
+            category: category)
+        
+        // 전달한 미션 정보를 코어데이터에 저장
+        missionUseCaseImpl.saveMissionData(title: title, assigneeId: member.userID, assigneeNickname: member.nickname, createDate: createDate, dueDate: dueDate, category: category)
         
         return missionUseCaseImpl.createMission(groupId: user.groupID, mission: mission)
     }

--- a/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
+++ b/StampIt-Project/StampIt-ProjectTests/UseCaseTests/MissionRepositoryTest.swift
@@ -174,4 +174,13 @@ final class MissionRepositoryTest: MissionRepository {
     func fetchSampleMission(withId missionId: String) -> [SampleMission] {
         return []
     }
+    
+    // 전달한 미션 정보를 코어데이터에 저장
+    func saveMissionData(title: String, assigneeId: String, assigneeNickname: String, createDate: Date, dueDate: Date, category: MissionCategory) {
+    }
+    
+    // 코어데이터 미션 데이터를 패치
+    func fetchMissionData() -> [MissionData] {
+        return []
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
STAMPIT-240

## 📌 변경 사항 및 이유
코어데이터 엔티티를 추가했습니다.
추가한 이유는 1. 사용자가 커스텀 미션을 생성할 때, 과거 정보를 바탕으로 자동완성 또는 추천 기능을 구현 2. 향후 AI가 자동완성 또는 추천 기능을 제공할 때 AI 프롬프트로 제공

## 📌 구현 내역 스크린샷
생략

## 📌 PR Point
없음

## 📌 참고 사항
- 이 PR이 기존 PR에서 브랜치를 추가해서 만든건데, 기존 PR을 아직 머지 안해서 여기 다 붙어있네요. 만약 문제가 있다면 삭제하겠습니다.
- 현재 실제 사용자 기능상으로는 구현된게 없습니다.
- 저장하는 데이터에 미션 전달 받는 사람 ID와 닉네임 두가지를 다 저장하는 이유는 1. ID는 일반적인 목적으로 사용(사용자 식별 등) 2. 닉네임은 AI가 사용자와 대상자의 관계를 추론하는데 도움을 주기 위함(실제 가능할지는 모르겠음. 뇌피셜)