### PR TITLE
[Feat] STAMPIT-241 - Firebase Analytics Event 구현

### DIFF
--- a/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
+++ b/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		783A885D2DF1506C0095BF4E /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 783A885C2DF1506C0095BF4E /* FirebaseStorage */; };
 		783A8A132DF599670095BF4E /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 783A8A122DF599670095BF4E /* GoogleSignIn */; };
 		783A8A152DF599670095BF4E /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 783A8A142DF599670095BF4E /* GoogleSignInSwift */; };
+		870EC2CD2E446D810021A713 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 870EC2CC2E446D810021A713 /* FirebaseAnalytics */; };
+		870EC2CF2E446D810021A713 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,7 +112,9 @@
 				783A88512DF1506C0095BF4E /* FirebaseCore in Frameworks */,
 				783A875D2DF02D1F0095BF4E /* Lottie in Frameworks */,
 				783A87582DF02D100095BF4E /* RxRelay in Frameworks */,
+				870EC2CF2E446D810021A713 /* FirebaseAnalyticsCore in Frameworks */,
 				783A88532DF1506C0095BF4E /* FirebaseDatabase in Frameworks */,
+				870EC2CD2E446D810021A713 /* FirebaseAnalytics in Frameworks */,
 				783A87532DF02CFA0095BF4E /* SnapKit in Frameworks */,
 				783A87562DF02D100095BF4E /* RxCocoa in Frameworks */,
 				783A885D2DF1506C0095BF4E /* FirebaseStorage in Frameworks */,
@@ -144,6 +148,7 @@
 				783A87162DF02CA80095BF4E /* StampIt-Project */,
 				783A87302DF02CA90095BF4E /* StampIt-ProjectTests */,
 				783A873A2DF02CA90095BF4E /* StampIt-ProjectUITests */,
+				870EC2CB2E446D810021A713 /* Frameworks */,
 				783A87152DF02CA80095BF4E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -156,6 +161,13 @@
 				783A87372DF02CA90095BF4E /* StampIt-ProjectUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		870EC2CB2E446D810021A713 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -192,6 +204,8 @@
 				783A885C2DF1506C0095BF4E /* FirebaseStorage */,
 				783A8A122DF599670095BF4E /* GoogleSignIn */,
 				783A8A142DF599670095BF4E /* GoogleSignInSwift */,
+				870EC2CC2E446D810021A713 /* FirebaseAnalytics */,
+				870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */,
 			);
 			productName = "StampIt-Project";
 			productReference = 783A87142DF02CA80095BF4E /* StampIt-Project.app */;
@@ -405,11 +419,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "StampIt-Project/StampIt-Project.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 373K7546A3;
+				DEVELOPMENT_TEAM = 373K7546A3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StampIt-Project/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Stamp It";
@@ -426,7 +438,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-Stamp-It-Project";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = iOS_Developer_Profile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -799,6 +810,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 783A8A112DF599670095BF4E /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
 			productName = GoogleSignInSwift;
+		};
+		870EC2CC2E446D810021A713 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 783A88492DF1506C0095BF4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 783A88492DF1506C0095BF4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Analytics/AnalyticsManager.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Analytics/AnalyticsManager.swift
@@ -1,0 +1,53 @@
+//
+//  AnalyticsManager.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/7/25.
+//
+
+import FirebaseAnalytics
+
+protocol AnalyticsManagerProtocol {
+    func logScreenView(screenName: String)
+    func logClickEvent(screen: String, position: String, coordinates: CGPoint?)
+    func logScreenDuration(screen: String, duration: TimeInterval)
+}
+
+final class AnalyticsManager: AnalyticsManagerProtocol {
+    static let shared = AnalyticsManager()
+    
+    private init() {}
+    
+    // 스크린 타임 기록
+    func logScreenView(screenName: String) {
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+            AnalyticsParameterScreenName: screenName,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+    
+    // 클릭 위치 기록
+    func logClickEvent(screen: String, position: String, coordinates: CGPoint? = nil) {
+        var parameters: [String: Any] = [
+            "screen": screen,
+            "position": position,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+        
+        if let coords = coordinates {
+            parameters["tap_x"] = coords.x
+            parameters["tap_y"] = coords.y
+        }
+        
+        Analytics.logEvent("click_event", parameters: parameters)
+    }
+    
+    // 머문 시간 기록
+    func logScreenDuration(screen: String, duration: TimeInterval) {
+        Analytics.logEvent("screen_duration", parameters: [
+            "screen": screen,
+            "duration_seconds": duration,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Analytics/BaseViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Analytics/BaseViewController.swift
@@ -1,0 +1,55 @@
+//
+//  BaseViewController.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/7/25.
+//
+
+import UIKit
+
+class BaseViewController: UIViewController {
+    private var screenStartTime: Date?
+    private let analytics = AnalyticsManager.shared
+    
+    // 서브클래스에서 오버라이드할 화면 이름
+    var screenName: String {
+        return String(describing: type(of: self)).replacingOccurrences(of: "ViewController", with: "")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupAnalyticsGesture()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        screenStartTime = Date()
+        analytics.logScreenView(screenName: screenName)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        trackScreenTime()
+    }
+    
+    private func setupAnalyticsGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleScreenTap(_:)))
+        tapGesture.cancelsTouchesInView = false // 다른 터치 이벤트 방해하지 않음
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func handleScreenTap(_ gesture: UITapGestureRecognizer) {
+        let location = gesture.location(in: view)
+        analytics.logClickEvent(
+            screen: screenName,
+            position: "screen_tap",
+            coordinates: location
+        )
+    }
+    
+    private func trackScreenTime() {
+        guard let startTime = screenStartTime else { return }
+        let duration = Date().timeIntervalSince(startTime)
+        analytics.logScreenDuration(screen: screenName, duration: duration)
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewController/HomeViewController.swift
@@ -11,12 +11,14 @@ import Then
 import RxSwift
 import RxCocoa
 
-final class HomeViewController: UIViewController {
+final class HomeViewController: BaseViewController {
 
     // MARK: - Properties
 
     private let viewModel: HomeViewModel
     private let disposeBag = DisposeBag()
+    
+    override var screenName: String { "Home" }
 
     // MARK: - UI Components
 

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/AssignMissionViewController.swift
@@ -12,7 +12,10 @@ import RxCocoa
 import SnapKit
 import Then
 
-final class AssignMissionViewController: UIViewController {
+final class AssignMissionViewController: BaseViewController {
+    
+    override var screenName: String { "AssignMission" }
+    
     private let navigationBar = DefaultNavigationBar(.titleWithBackButton(title: "미션 전달하기"))
     
     private let missionTitleTextField = UITextField().then {

--- a/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Mission/View/MissionListViewController.swift
@@ -11,7 +11,10 @@ import RxCocoa
 import SnapKit
 import Then
 
-final class MissionListViewController: UIViewController {
+final class MissionListViewController: BaseViewController {
+    
+    override var screenName: String { "MissionList" }
+    
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     
     private let navigationBar = DefaultNavigationBar(.plainTitle(title: "미션"))

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/StampBoardViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/ViewController/StampBoardViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxRelay
 
-final class StampBoardViewController: UIViewController {
+final class StampBoardViewController: BaseViewController {
     
     // MARK: - Properties
     
@@ -19,6 +19,8 @@ final class StampBoardViewController: UIViewController {
     private var container: DIContainer
     private let disposeBag = DisposeBag()
     private var currentPage: Int = .zero
+    
+    override var screenName: String { "StampBoard" }
     
     // MARK: - UI Components
 


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-241

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. AnalyticsManager 싱글톤 패턴(DI 불필요)으로 Presentation Common>Analytics 폴더 안에 구현
2. 스크린 접속 타임 기록, 화면 클릭 위치, 머문 시간 기록하는 메서드 구현
3. 간단한 데이터만 기록하는 구조라 Data-Repository, Domain-UseCase, DI까지 아키텍처 계층별 분리하지 않음(클린 아키텍처적으로 구현X)
4. UIVC 대신 상속받을 Analytics 이벤트 정보가 담긴 BaseVC 구현함
5. 오버라이드를 통해 이벤트에 저장될 스크린 화면 이름을 바꿀 수 있음
6. UIVC -> BaseVC로 상속 클래스 변경
7. 실기기에서 테스트 필요, 시뮬레이터에서는 데이터 수집 안됨

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
하경님, 다은님, 순욱님의 각 스탬프판, 홈, 미션리스트, 미션전달 화면에서 상속받는 VC가 BaseVC로 변경되었습니다! 문제 있다면 PR 전에 말씀 부탁드립니다. 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
자세한 내용은 정리해둔 아래 가이드 확인하시면 됩니다! 그리고 시뮬레이터에서는 데이터 수집이 안돼서 월요일에 1.1.6 배포 진행하고 데이터 잘 쌓이는지 확인해야할 것 같습니다.
가이드: https://daffodil-twist-1a4.notion.site/92-Swift-91-_-Firestore-Analytics-2486b5542f2980ef89d0fd1504ac89bd