### PR TITLE
[Feat] STAMPIT-226 - 위젯 구현

### DIFF
--- a/StampIt-Project/MissionWidget/Info.plist
+++ b/StampIt-Project/MissionWidget/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>내 미션</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.1.5</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/StampIt-Project/MissionWidget/MissionProvider.swift
+++ b/StampIt-Project/MissionWidget/MissionProvider.swift
@@ -9,44 +9,34 @@ import WidgetKit
 
 struct MissionTimelineProvider: TimelineProvider {
     func placeholder(in context: Context) -> MissionEntry {
-        MissionEntry(date: Date(), missions: getSampleMissions())
+        MissionEntry(date: Date(), missions: fetchMissions())
     }
     
     func getSnapshot(in context: Context, completion: @escaping (MissionEntry) -> ()) {
-        let entry = MissionEntry(date: Date(), missions: getSampleMissions())
+        let entry = MissionEntry(date: Date(), missions: fetchMissions())
         completion(entry)
     }
     
     func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
-        let missions = fetchMissions().isEmpty ? getSampleMissions() : fetchMissions()
+        let missions = fetchMissions()
         let entry = MissionEntry(date: Date(), missions: missions)
         let timeline = Timeline(entries: [entry], policy: .atEnd)
         completion(timeline)
     }
     
-    private func fetchMissions() -> [Mission] {
-        // TODO: 실제 API 호출 로직으로 변경 예정
+    private func fetchMissions() -> [MissionWidgetUI] {
+        let defaults = UserDefaults(suiteName: "group.com.by.Family-Stamp-It-Widget-")
+        if let data = defaults?.data(forKey: "missions"),
+           let missions = try? JSONDecoder().decode([MissionWidgetUI].self, from: data) {
+            print("미션 데이터: \(missions)")
+        } else {
+            print("미션 데이터 없음!")
+        }
+        guard let data = defaults?.data(forKey: "missions") else { return [] }
+        let decoder = JSONDecoder()
+        if let missions = try? decoder.decode([MissionWidgetUI].self, from: data) {
+            return missions
+        }
         return []
-    }
-    
-    private func getSampleMissions() -> [Mission] {
-        return [
-            Mission(
-                id: "1",
-                title: "미션내용입니다미션내용미션내용미션내용미션내용",
-                fromLabel: "from.label",
-                duration: "~기간",
-                isNew: true,
-                category: .chore
-            ),
-            Mission(
-                id: "2",
-                title: "미션내용입니다미션내용미션내용미션내용미션내용",
-                fromLabel: "from.label",
-                duration: "~기간",
-                isNew: true,
-                category: .health
-            )
-        ]
     }
 }

--- a/StampIt-Project/MissionWidget/MissionProvider.swift
+++ b/StampIt-Project/MissionWidget/MissionProvider.swift
@@ -25,13 +25,8 @@ struct MissionTimelineProvider: TimelineProvider {
     }
     
     private func fetchMissions() -> [MissionWidgetUI] {
-        let defaults = UserDefaults(suiteName: "group.com.by.Family-Stamp-It-Widget-")
-        if let data = defaults?.data(forKey: "missions"),
-           let missions = try? JSONDecoder().decode([MissionWidgetUI].self, from: data) {
-            print("미션 데이터: \(missions)")
-        } else {
-            print("미션 데이터 없음!")
-        }
+        let defaults = UserDefaults(suiteName: "group.com.by.Family-Stamp-It-Widget-AppGroups")
+
         guard let data = defaults?.data(forKey: "missions") else { return [] }
         let decoder = JSONDecoder()
         if let missions = try? decoder.decode([MissionWidgetUI].self, from: data) {

--- a/StampIt-Project/MissionWidget/MissionProvider.swift
+++ b/StampIt-Project/MissionWidget/MissionProvider.swift
@@ -1,0 +1,52 @@
+//
+//  MissionProvider.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import WidgetKit
+
+struct MissionTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> MissionEntry {
+        MissionEntry(date: Date(), missions: getSampleMissions())
+    }
+    
+    func getSnapshot(in context: Context, completion: @escaping (MissionEntry) -> ()) {
+        let entry = MissionEntry(date: Date(), missions: getSampleMissions())
+        completion(entry)
+    }
+    
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        let missions = fetchMissions().isEmpty ? getSampleMissions() : fetchMissions()
+        let entry = MissionEntry(date: Date(), missions: missions)
+        let timeline = Timeline(entries: [entry], policy: .atEnd)
+        completion(timeline)
+    }
+    
+    private func fetchMissions() -> [Mission] {
+        // TODO: 실제 API 호출 로직으로 변경 예정
+        return []
+    }
+    
+    private func getSampleMissions() -> [Mission] {
+        return [
+            Mission(
+                id: "1",
+                title: "미션내용입니다미션내용미션내용미션내용미션내용",
+                fromLabel: "from.label",
+                duration: "~기간",
+                isNew: true,
+                category: .chore
+            ),
+            Mission(
+                id: "2",
+                title: "미션내용입니다미션내용미션내용미션내용미션내용",
+                fromLabel: "from.label",
+                duration: "~기간",
+                isNew: true,
+                category: .health
+            )
+        ]
+    }
+}

--- a/StampIt-Project/MissionWidget/MissionProvider.swift
+++ b/StampIt-Project/MissionWidget/MissionProvider.swift
@@ -24,12 +24,12 @@ struct MissionTimelineProvider: TimelineProvider {
         completion(timeline)
     }
     
-    private func fetchMissions() -> [MissionWidgetUI] {
+    private func fetchMissions() -> [HomeMissionWidget] {
         let defaults = UserDefaults(suiteName: "group.com.by.Family-Stamp-It-Widget-AppGroups")
 
         guard let data = defaults?.data(forKey: "missions") else { return [] }
         let decoder = JSONDecoder()
-        if let missions = try? decoder.decode([MissionWidgetUI].self, from: data) {
+        if let missions = try? decoder.decode([HomeMissionWidget].self, from: data) {
             return missions
         }
         return []

--- a/StampIt-Project/MissionWidget/MissionWidget.swift
+++ b/StampIt-Project/MissionWidget/MissionWidget.swift
@@ -1,0 +1,22 @@
+//
+//  MissionWidget.swift
+//  MissionWidget
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct MissionWidget: Widget {
+    let kind: String = "MissionWidget"
+    
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: MissionTimelineProvider()) { entry in
+            MissionWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("내 미션")
+        .description("오늘의 미션을 확인하세요")
+        .supportedFamilies([.systemMedium])
+    }
+}

--- a/StampIt-Project/MissionWidget/MissionWidgetBundle.swift
+++ b/StampIt-Project/MissionWidget/MissionWidgetBundle.swift
@@ -1,0 +1,16 @@
+//
+//  MissionWidgetBundle.swift
+//  MissionWidget
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct MissionWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        MissionWidget()
+    }
+}

--- a/StampIt-Project/MissionWidget/MissionWidgetView.swift
+++ b/StampIt-Project/MissionWidget/MissionWidgetView.swift
@@ -113,11 +113,8 @@ struct MissionRowView: View {
     
     private var missionIcon: some View {
         mission.category.widgetImage
-            .foregroundColor(.blue)
-            .font(.system(size: 16))
+            .resizable()
             .frame(width: 32, height: 32)
-            .background(Color.blue.opacity(0.1))
-            .cornerRadius(8)
     }
 }
 

--- a/StampIt-Project/MissionWidget/MissionWidgetView.swift
+++ b/StampIt-Project/MissionWidget/MissionWidgetView.swift
@@ -57,7 +57,7 @@ struct MissionWidgetEntryView: View {
     
     private var missionListView: some View {
         VStack(spacing: 0) {
-            ForEach(entry.missions.prefix(2), id: \.id) { mission in
+            ForEach(entry.missions.prefix(2)) { mission in
                 MissionRowView(mission: mission)
             }
         }

--- a/StampIt-Project/MissionWidget/MissionWidgetView.swift
+++ b/StampIt-Project/MissionWidget/MissionWidgetView.swift
@@ -66,7 +66,7 @@ struct MissionWidgetEntryView: View {
 }
 
 struct MissionRowView: View {
-    let mission: Mission
+    let mission: MissionWidgetUI
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {

--- a/StampIt-Project/MissionWidget/MissionWidgetView.swift
+++ b/StampIt-Project/MissionWidget/MissionWidgetView.swift
@@ -1,0 +1,147 @@
+//
+//  MissionWidgetView.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct MissionWidgetEntryView: View {
+    var entry: MissionTimelineProvider.Entry
+    
+    var body: some View {
+        ZStack {
+            Color.white
+            
+            VStack(alignment: .leading, spacing: 0) {
+                // 헤더
+                headerView
+                
+                if entry.missions.isEmpty {
+                    emptyStateView
+                } else {
+                    missionListView
+                }
+                
+                Spacer()
+            }
+        }
+        .widgetURL(URL(string: "stampIt://mission"))
+    }
+    
+    // MARK: - Views
+    private var headerView: some View {
+        HStack {
+            Text("내 미션")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.black)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 20)
+        .padding(.bottom, 5)
+    }
+    
+    private var emptyStateView: some View {
+        VStack {
+            Spacer()
+            Text("아직 받은 미션이 없어요!")
+                .font(.system(size: 14))
+                .foregroundColor(.gray)
+                .padding(.horizontal, 16)
+            Spacer()
+        }
+    }
+    
+    private var missionListView: some View {
+        VStack(spacing: 0) {
+            ForEach(entry.missions.prefix(2), id: \.id) { mission in
+                MissionRowView(mission: mission)
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+struct MissionRowView: View {
+    let mission: Mission
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // 미션 내용
+            VStack(alignment: .leading, spacing: 4) {
+                tagRow
+                // 미션 제목
+                missionTitle
+            }
+            
+            Spacer()
+            
+            // 미션 아이콘
+            missionIcon
+        }
+        .padding(.vertical, 6)
+    }
+    
+    // MARK: - Components
+    private var tagRow: some View {
+        HStack(spacing: 6) {
+            // new 태그
+            if mission.isNew {
+                TagView(text: "new", isHighlighted: true)
+            }
+            
+            // from.label 태그
+            TagView(text: mission.fromLabel, isHighlighted: false)
+            
+            // ~기간 태그
+            TagView(text: mission.duration, isHighlighted: false)
+            
+            Spacer()
+        }
+    }
+    
+    private var missionTitle: some View {
+        Text(mission.title)
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(.black)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+    
+    private var missionIcon: some View {
+        mission.category.widgetImage
+            .foregroundColor(.blue)
+            .font(.system(size: 16))
+            .frame(width: 32, height: 32)
+            .background(Color.blue.opacity(0.1))
+            .cornerRadius(8)
+    }
+}
+
+struct TagView: View {
+    let text: String
+    let isHighlighted: Bool
+    
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(isHighlighted ?
+                Color(red: 1.0, green: 0.8, blue: 0.0) :
+                Color.gray
+            )
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(
+                        isHighlighted ?
+                        Color(red: 1.0, green: 0.8, blue: 0.0) :
+                        Color.gray,
+                        lineWidth: 1
+                    )
+            )
+    }
+}

--- a/StampIt-Project/MissionWidget/MissionWidgetView.swift
+++ b/StampIt-Project/MissionWidget/MissionWidgetView.swift
@@ -66,7 +66,7 @@ struct MissionWidgetEntryView: View {
 }
 
 struct MissionRowView: View {
-    let mission: MissionWidgetUI
+    let mission: HomeMissionWidget
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {

--- a/StampIt-Project/MissionWidget/WidgetMissionCategory+Extension.swift
+++ b/StampIt-Project/MissionWidget/WidgetMissionCategory+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  WidgetMissionCategory+Extension.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import SwiftUI
+
+extension MissionCategory {
+    var widgetImage: Image {
+        let imageName: String
+        switch self {
+            case .chore: imageName = "chore"
+            case .communication: imageName = "communication"
+            case .health: imageName = "health"
+            case .learning: imageName = "learning"
+            case .custom: imageName = "custom"
+        }
+        return Image(imageName)
+    }
+}

--- a/StampIt-Project/MissionWidget/WidgetMissionCategory+Extension.swift
+++ b/StampIt-Project/MissionWidget/WidgetMissionCategory+Extension.swift
@@ -9,14 +9,17 @@ import SwiftUI
 
 extension MissionCategory {
     var widgetImage: Image {
-        let imageName: String
         switch self {
-            case .chore: imageName = "chore"
-            case .communication: imageName = "communication"
-            case .health: imageName = "health"
-            case .learning: imageName = "learning"
-            case .custom: imageName = "custom"
+        case .chore:
+            Image("chore")
+        case .communication:
+            Image("communication")
+        case .health:
+            Image("health")
+        case .learning:
+            Image("learning")
+        case .custom:
+            Image("custom")
         }
-        return Image(imageName)
     }
 }

--- a/StampIt-Project/MissionWidget/WidgetMissionEntity.swift
+++ b/StampIt-Project/MissionWidget/WidgetMissionEntity.swift
@@ -9,7 +9,7 @@ import WidgetKit
 
 struct MissionEntry: TimelineEntry {
     let date: Date
-    let missions: [MissionWidgetUI]
+    let missions: [HomeMissionWidget]
 }
 
 struct Mission {

--- a/StampIt-Project/MissionWidget/WidgetMissionEntity.swift
+++ b/StampIt-Project/MissionWidget/WidgetMissionEntity.swift
@@ -9,7 +9,7 @@ import WidgetKit
 
 struct MissionEntry: TimelineEntry {
     let date: Date
-    let missions: [Mission]
+    let missions: [MissionWidgetUI]
 }
 
 struct Mission {

--- a/StampIt-Project/MissionWidget/WidgetMissionEntity.swift
+++ b/StampIt-Project/MissionWidget/WidgetMissionEntity.swift
@@ -1,0 +1,22 @@
+//
+//  WidgetMissionEntity.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import WidgetKit
+
+struct MissionEntry: TimelineEntry {
+    let date: Date
+    let missions: [Mission]
+}
+
+struct Mission {
+    let id: String
+    let title: String
+    let fromLabel: String
+    let duration: String
+    let isNew: Bool
+    let category: MissionCategory
+}

--- a/StampIt-Project/MissionWidgetExtensionRelease.entitlements
+++ b/StampIt-Project/MissionWidgetExtensionRelease.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.usernotifications.communication</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.by.Family-Stamp-It-Widget-AppGroups</string>

--- a/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
+++ b/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
@@ -22,8 +22,6 @@
 		783A885D2DF1506C0095BF4E /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 783A885C2DF1506C0095BF4E /* FirebaseStorage */; };
 		783A8A132DF599670095BF4E /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 783A8A122DF599670095BF4E /* GoogleSignIn */; };
 		783A8A152DF599670095BF4E /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 783A8A142DF599670095BF4E /* GoogleSignInSwift */; };
-		870EC2CD2E446D810021A713 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 870EC2CC2E446D810021A713 /* FirebaseAnalytics */; };
-		870EC2CF2E446D810021A713 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */; };
 		877339CC2E45AF1C00FA2885 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 877339CB2E45AF1C00FA2885 /* WidgetKit.framework */; };
 		877339CE2E45AF1C00FA2885 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 877339CD2E45AF1C00FA2885 /* SwiftUI.framework */; };
 		877339DB2E45AF1D00FA2885 /* MissionWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 877339C92E45AF1C00FA2885 /* MissionWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -112,7 +110,6 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Domain/Entities/MissionCategory.swift,
-				Presentation/Common/Manager/WidgetMissionManager.swift,
 				Presentation/Common/Model/HomeMissionWidget.swift,
 				"Presentation/Common/Model/MissionCategory+Extension.swift",
 				Presentation/MyPage/Model/MissionUI.swift,
@@ -168,9 +165,7 @@
 				783A88512DF1506C0095BF4E /* FirebaseCore in Frameworks */,
 				783A875D2DF02D1F0095BF4E /* Lottie in Frameworks */,
 				783A87582DF02D100095BF4E /* RxRelay in Frameworks */,
-				870EC2CF2E446D810021A713 /* FirebaseAnalyticsCore in Frameworks */,
 				783A88532DF1506C0095BF4E /* FirebaseDatabase in Frameworks */,
-				870EC2CD2E446D810021A713 /* FirebaseAnalytics in Frameworks */,
 				783A87532DF02CFA0095BF4E /* SnapKit in Frameworks */,
 				783A87562DF02D100095BF4E /* RxCocoa in Frameworks */,
 				783A885D2DF1506C0095BF4E /* FirebaseStorage in Frameworks */,
@@ -240,13 +235,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		870EC2CB2E446D810021A713 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -283,8 +271,6 @@
 				783A885C2DF1506C0095BF4E /* FirebaseStorage */,
 				783A8A122DF599670095BF4E /* GoogleSignIn */,
 				783A8A142DF599670095BF4E /* GoogleSignInSwift */,
-				870EC2CC2E446D810021A713 /* FirebaseAnalytics */,
-				870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */,
 			);
 			productName = "StampIt-Project";
 			productReference = 783A87142DF02CA80095BF4E /* StampIt-Project.app */;
@@ -1010,16 +996,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 783A8A112DF599670095BF4E /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
 			productName = GoogleSignInSwift;
-		};
-		870EC2CC2E446D810021A713 /* FirebaseAnalytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 783A88492DF1506C0095BF4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalytics;
-		};
-		870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 783A88492DF1506C0095BF4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
+++ b/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		877339C92E45AF1C00FA2885 /* MissionWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MissionWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		877339CB2E45AF1C00FA2885 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		877339CD2E45AF1C00FA2885 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		87733A002E45D68500FA2885 /* MissionWidgetExtensionRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MissionWidgetExtensionRelease.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -111,7 +112,10 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Domain/Entities/MissionCategory.swift,
+				Presentation/Common/Manager/WidgetMissionManager.swift,
 				"Presentation/Common/Model/MissionCategory+Extension.swift",
+				Presentation/Common/Model/MissionWidgetUI.swift,
+				Presentation/MyPage/Model/MissionUI.swift,
 				Resource/Assets.xcassets,
 			);
 			target = 877339C82E45AF1C00FA2885 /* MissionWidgetExtension */;
@@ -206,6 +210,7 @@
 		783A870B2DF02CA80095BF4E = {
 			isa = PBXGroup;
 			children = (
+				87733A002E45D68500FA2885 /* MissionWidgetExtensionRelease.entitlements */,
 				783A87162DF02CA80095BF4E /* StampIt-Project */,
 				783A87302DF02CA90095BF4E /* StampIt-ProjectTests */,
 				783A873A2DF02CA90095BF4E /* StampIt-ProjectUITests */,
@@ -502,8 +507,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 373K7546A3;
+				DEVELOPMENT_TEAM = 373K7546A3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StampIt-Project/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Stamp It";
@@ -801,11 +805,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = MissionWidgetExtensionRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 373K7546A3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MissionWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MissionWidget;

--- a/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
+++ b/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		783A8A152DF599670095BF4E /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 783A8A142DF599670095BF4E /* GoogleSignInSwift */; };
 		870EC2CD2E446D810021A713 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 870EC2CC2E446D810021A713 /* FirebaseAnalytics */; };
 		870EC2CF2E446D810021A713 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 870EC2CE2E446D810021A713 /* FirebaseAnalyticsCore */; };
+		877339CC2E45AF1C00FA2885 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 877339CB2E45AF1C00FA2885 /* WidgetKit.framework */; };
+		877339CE2E45AF1C00FA2885 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 877339CD2E45AF1C00FA2885 /* SwiftUI.framework */; };
+		877339DB2E45AF1D00FA2885 /* MissionWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 877339C92E45AF1C00FA2885 /* MissionWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,12 +44,36 @@
 			remoteGlobalIDString = 783A87132DF02CA80095BF4E;
 			remoteInfo = "StampIt-Project";
 		};
+		877339D92E45AF1D00FA2885 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 783A870C2DF02CA80095BF4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 877339C82E45AF1C00FA2885;
+			remoteInfo = MissionWidgetExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		877339DC2E45AF1D00FA2885 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				877339DB2E45AF1D00FA2885 /* MissionWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		783A87142DF02CA80095BF4E /* StampIt-Project.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "StampIt-Project.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		783A872D2DF02CA90095BF4E /* StampIt-ProjectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StampIt-ProjectTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		783A87372DF02CA90095BF4E /* StampIt-ProjectUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StampIt-ProjectUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		877339C92E45AF1C00FA2885 /* MissionWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MissionWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		877339CB2E45AF1C00FA2885 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		877339CD2E45AF1C00FA2885 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -73,6 +100,22 @@
 			);
 			target = 783A87132DF02CA80095BF4E /* StampIt-Project */;
 		};
+		877339E02E45AF1D00FA2885 /* Exceptions for "MissionWidget" folder in "MissionWidgetExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 877339C82E45AF1C00FA2885 /* MissionWidgetExtension */;
+		};
+		877339EC2E45B50000FA2885 /* Exceptions for "StampIt-Project" folder in "MissionWidgetExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Domain/Entities/MissionCategory.swift,
+				"Presentation/Common/Model/MissionCategory+Extension.swift",
+				Resource/Assets.xcassets,
+			);
+			target = 877339C82E45AF1C00FA2885 /* MissionWidgetExtension */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -80,6 +123,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				783A873F2DF02CA90095BF4E /* Exceptions for "StampIt-Project" folder in "StampIt-Project" target */,
+				877339EC2E45B50000FA2885 /* Exceptions for "StampIt-Project" folder in "MissionWidgetExtension" target */,
 			);
 			path = "StampIt-Project";
 			sourceTree = "<group>";
@@ -96,6 +140,14 @@
 		783A873A2DF02CA90095BF4E /* StampIt-ProjectUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "StampIt-ProjectUITests";
+			sourceTree = "<group>";
+		};
+		877339CF2E45AF1C00FA2885 /* MissionWidget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				877339E02E45AF1D00FA2885 /* Exceptions for "MissionWidget" folder in "MissionWidgetExtension" target */,
+			);
+			path = MissionWidget;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -139,6 +191,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		877339C62E45AF1C00FA2885 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				877339CE2E45AF1C00FA2885 /* SwiftUI.framework in Frameworks */,
+				877339CC2E45AF1C00FA2885 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -148,7 +209,8 @@
 				783A87162DF02CA80095BF4E /* StampIt-Project */,
 				783A87302DF02CA90095BF4E /* StampIt-ProjectTests */,
 				783A873A2DF02CA90095BF4E /* StampIt-ProjectUITests */,
-				870EC2CB2E446D810021A713 /* Frameworks */,
+				877339CF2E45AF1C00FA2885 /* MissionWidget */,
+				877339CA2E45AF1C00FA2885 /* Frameworks */,
 				783A87152DF02CA80095BF4E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -159,8 +221,18 @@
 				783A87142DF02CA80095BF4E /* StampIt-Project.app */,
 				783A872D2DF02CA90095BF4E /* StampIt-ProjectTests.xctest */,
 				783A87372DF02CA90095BF4E /* StampIt-ProjectUITests.xctest */,
+				877339C92E45AF1C00FA2885 /* MissionWidgetExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		877339CA2E45AF1C00FA2885 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				877339CB2E45AF1C00FA2885 /* WidgetKit.framework */,
+				877339CD2E45AF1C00FA2885 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		870EC2CB2E446D810021A713 /* Frameworks */ = {
@@ -180,10 +252,12 @@
 				783A87102DF02CA80095BF4E /* Sources */,
 				783A87112DF02CA80095BF4E /* Frameworks */,
 				783A87122DF02CA80095BF4E /* Resources */,
+				877339DC2E45AF1D00FA2885 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				877339DA2E45AF1D00FA2885 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				783A87162DF02CA80095BF4E /* StampIt-Project */,
@@ -258,6 +332,28 @@
 			productReference = 783A87372DF02CA90095BF4E /* StampIt-ProjectUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		877339C82E45AF1C00FA2885 /* MissionWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 877339DF2E45AF1D00FA2885 /* Build configuration list for PBXNativeTarget "MissionWidgetExtension" */;
+			buildPhases = (
+				877339C52E45AF1C00FA2885 /* Sources */,
+				877339C62E45AF1C00FA2885 /* Frameworks */,
+				877339C72E45AF1C00FA2885 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				877339CF2E45AF1C00FA2885 /* MissionWidget */,
+			);
+			name = MissionWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = MissionWidgetExtension;
+			productReference = 877339C92E45AF1C00FA2885 /* MissionWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -265,7 +361,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1620;
+				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					783A87132DF02CA80095BF4E = {
@@ -278,6 +374,9 @@
 					783A87362DF02CA90095BF4E = {
 						CreatedOnToolsVersion = 16.2;
 						TestTargetID = 783A87132DF02CA80095BF4E;
+					};
+					877339C82E45AF1C00FA2885 = {
+						CreatedOnToolsVersion = 16.4;
 					};
 				};
 			};
@@ -307,6 +406,7 @@
 				783A87132DF02CA80095BF4E /* StampIt-Project */,
 				783A872C2DF02CA90095BF4E /* StampIt-ProjectTests */,
 				783A87362DF02CA90095BF4E /* StampIt-ProjectUITests */,
+				877339C82E45AF1C00FA2885 /* MissionWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -327,6 +427,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		783A87352DF02CA90095BF4E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		877339C72E45AF1C00FA2885 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -357,6 +464,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		877339C52E45AF1C00FA2885 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -369,6 +483,11 @@
 			isa = PBXTargetDependency;
 			target = 783A87132DF02CA80095BF4E /* StampIt-Project */;
 			targetProxy = 783A87382DF02CA90095BF4E /* PBXContainerItemProxy */;
+		};
+		877339DA2E45AF1D00FA2885 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 877339C82E45AF1C00FA2885 /* MissionWidgetExtension */;
+			targetProxy = 877339D92E45AF1D00FA2885 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -643,6 +762,74 @@
 			};
 			name = Release;
 		};
+		877339DD2E45AF1D00FA2885 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MissionWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = MissionWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 16;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-Stamp-It-Project.MissionWidget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		877339DE2E45AF1D00FA2885 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MissionWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = MissionWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 16;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.by.Family-Stamp-It-Project.MissionWidget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -678,6 +865,15 @@
 			buildConfigurations = (
 				783A87492DF02CA90095BF4E /* Debug */,
 				783A874A2DF02CA90095BF4E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		877339DF2E45AF1D00FA2885 /* Build configuration list for PBXNativeTarget "MissionWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				877339DD2E45AF1D00FA2885 /* Debug */,
+				877339DE2E45AF1D00FA2885 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
+++ b/StampIt-Project/StampIt-Project.xcodeproj/project.pbxproj
@@ -113,8 +113,8 @@
 			membershipExceptions = (
 				Domain/Entities/MissionCategory.swift,
 				Presentation/Common/Manager/WidgetMissionManager.swift,
+				Presentation/Common/Model/HomeMissionWidget.swift,
 				"Presentation/Common/Model/MissionCategory+Extension.swift",
-				Presentation/Common/Model/MissionWidgetUI.swift,
 				Presentation/MyPage/Model/MissionUI.swift,
 				Resource/Assets.xcassets,
 			);

--- a/StampIt-Project/StampIt-Project/Domain/Entities/MissionCategory.swift
+++ b/StampIt-Project/StampIt-Project/Domain/Entities/MissionCategory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum MissionCategory: String, CaseIterable, Decodable {
+enum MissionCategory: String, CaseIterable, Codable {
     case chore
     case communication
     case health

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Manager/WidgetMissionManager.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Manager/WidgetMissionManager.swift
@@ -1,0 +1,47 @@
+//
+//  WidgetMissionManager.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import Foundation
+
+final class WidgetMissionManager {
+    static let shared = WidgetMissionManager()
+    private let suiteName = "group.com.by.Family-Stamp-It-Widget-AppGroups"
+    private let key = "missions"
+    
+    private init() {}
+    
+    func save(missions: [MissionWidgetUI]) {
+        print("위젯 데이터 저장 시도: \(missions.count)개")
+        print("App Group ID: \(suiteName)")
+        
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(missions) {
+            let defaults = UserDefaults(suiteName: suiteName)
+            defaults?.set(data, forKey: key)
+            defaults?.synchronize() // 강제 동기화
+            
+            // 저장 확인
+            if let savedData = defaults?.data(forKey: key) {
+                print("데이터 저장 성공: \(savedData.count) bytes")
+                
+                // 디코딩 테스트
+                if let savedMissions = try? JSONDecoder().decode([MissionWidgetUI].self, from: savedData) {
+                    print("저장된 미션: \(savedMissions.count)개")
+                    for mission in savedMissions {
+                        print("  - \(mission.title)")
+                    }
+                } else {
+                    print("디코딩 실패")
+                }
+            } else {
+                print("데이터 저장 실패")
+            }
+        } else {
+            print("인코딩 실패")
+        }
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Manager/WidgetMissionManager.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Manager/WidgetMissionManager.swift
@@ -14,7 +14,7 @@ final class WidgetMissionManager {
     
     private init() {}
     
-    func save(missions: [MissionWidgetUI]) {
+    func save(missions: [HomeMissionWidget]) {
         print("위젯 데이터 저장 시도: \(missions.count)개")
         print("App Group ID: \(suiteName)")
         
@@ -29,7 +29,7 @@ final class WidgetMissionManager {
                 print("데이터 저장 성공: \(savedData.count) bytes")
                 
                 // 디코딩 테스트
-                if let savedMissions = try? JSONDecoder().decode([MissionWidgetUI].self, from: savedData) {
+                if let savedMissions = try? JSONDecoder().decode([HomeMissionWidget].self, from: savedData) {
                     print("저장된 미션: \(savedMissions.count)개")
                     for mission in savedMissions {
                         print("  - \(mission.title)")

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Model/HomeMissionWidget.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Model/HomeMissionWidget.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MissionWidgetUI: Codable {
+struct HomeMissionWidget: Codable, Identifiable {
     let id: String
     let title: String
     let fromLabel: String
@@ -16,7 +16,7 @@ struct MissionWidgetUI: Codable {
     let category: MissionCategory
 }
 
-extension MissionWidgetUI {
+extension HomeMissionWidget {
     init(from ui: MissionUI) {
         self.id = ui.missionID
         self.title = ui.title

--- a/StampIt-Project/StampIt-Project/Presentation/Common/Model/MissionWidgetUI.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Model/MissionWidgetUI.swift
@@ -1,0 +1,28 @@
+//
+//  MissionWidgetUI.swift
+//  StampIt-Project
+//
+//  Created by 이부용 on 8/8/25.
+//
+
+import Foundation
+
+struct MissionWidgetUI: Codable {
+    let id: String
+    let title: String
+    let fromLabel: String
+    let duration: String
+    let isNew: Bool
+    let category: MissionCategory
+}
+
+extension MissionWidgetUI {
+    init(from ui: MissionUI) {
+        self.id = ui.missionID
+        self.title = ui.title
+        self.category = ui.category
+        self.fromLabel = ui.nickname
+        self.duration = ui.dueDate
+        self.isNew = false
+    }
+}

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import RxSwift
 import RxRelay
+import WidgetKit
 
 final class HomeViewModel: ViewModelProtocol {
     // MARK: - Dependency
@@ -155,9 +156,24 @@ final class HomeViewModel: ViewModelProtocol {
                   .map(myMissions: missions, member: memberCache)
                   .map { HomeItem.myMission($0) }
               self.state.myMissions.accept(items)
+              print("저장할 미션 데이터: \(missions)")
+              
+              // 위젯 데이터 저장
+              let missionUIs = missions.map { $0.toPresentation() }
+              let widgetMissionUIs = missionUIs.map { MissionWidgetUI(from: $0) }
+              WidgetMissionManager.shared.save(missions: widgetMissionUIs)
+              WidgetCenter.shared.reloadAllTimelines() // 위젯 새로고침
+              let defaults = UserDefaults(suiteName: "group.com.by.Family-Stamp-It-Widget-")
+              if let data = defaults?.data(forKey: "missions"),
+                 let missions = try? JSONDecoder().decode([MissionWidgetUI].self, from: data) {
+                  print("미션 데이터: \(missions)")
+              } else {
+                  print("미션 데이터 없음!")
+              }
           })
           .disposed(by: disposeBag)
     }
+
 
     private func bindMemberMissions(ofUser currentUser: Observable<User>) {
         currentUser

--- a/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -160,12 +160,12 @@ final class HomeViewModel: ViewModelProtocol {
               
               // 위젯 데이터 저장
               let missionUIs = missions.map { $0.toPresentation() }
-              let widgetMissionUIs = missionUIs.map { MissionWidgetUI(from: $0) }
+              let widgetMissionUIs = missionUIs.map { HomeMissionWidget(from: $0) }
               WidgetMissionManager.shared.save(missions: widgetMissionUIs)
               WidgetCenter.shared.reloadAllTimelines() // 위젯 새로고침
               let defaults = UserDefaults(suiteName: "group.com.by.Family-Stamp-It-Widget-")
               if let data = defaults?.data(forKey: "missions"),
-                 let missions = try? JSONDecoder().decode([MissionWidgetUI].self, from: data) {
+                 let missions = try? JSONDecoder().decode([HomeMissionWidget].self, from: data) {
                   print("미션 데이터: \(missions)")
               } else {
                   print("미션 데이터 없음!")

--- a/StampIt-Project/StampIt-Project/Presentation/MyPage/Model/MissionUI.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/MyPage/Model/MissionUI.swift
@@ -14,3 +14,4 @@ struct MissionUI: Equatable {
     let dueDate: String
     let category: MissionCategory
 }
+


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-226

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 미션에 따른 출력내용 분기처리, 최대 2개의 받은 미션 출력
2. AppGroups 설정
3. 카테고리 별 출력 아이콘 변경

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
1.1.6 업데이트 배포용으로 올릴 예정입니다. SwiftUI로 구현되어 있습니다 (위젯 기준 SwiftUI가 기본)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 외부에서 올리고 있어어서 구현내역 스크린샷 생략합니다! 이전에 보내드렸던 민경님 기반 디자인대로 구현되어 있습니다.
- 시뮬레이터에서 앱과 위젯 동시 테스트의 한계로 TestFlight로 확인 필요합니다.
- HomeViewModel에서 미션 데이터 저장할 때 WidgetManager.shaerd를 통해 위젯에 전달할 데이터 저장 및 연동
- UserDefaults를 사용하여 앱과 위젯 간 데이터 공유
- 미션 카테고리 익스텐션을 위젯에 적용하기 위해 코드 수정 (Codable로 변경)