### PR TITLE
[Feat] STAMPIT-267 - 초대코드 공유하기 애널리틱스 정보 추가

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Common/Manager/AnalyticsManager.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Manager/AnalyticsManager.swift
@@ -11,6 +11,7 @@ protocol AnalyticsManagerProtocol {
     func logScreenView(screenName: String)
     func logClickEvent(screen: String, position: String, coordinates: CGPoint?)
     func logScreenDuration(screen: String, duration: TimeInterval)
+    func logInviteCodeShare(screen: String)
 }
 
 final class AnalyticsManager: AnalyticsManagerProtocol {
@@ -47,6 +48,14 @@ final class AnalyticsManager: AnalyticsManagerProtocol {
         Analytics.logEvent("screen_duration", parameters: [
             "screen": screen,
             "duration_seconds": duration,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+    
+    // 초대코드 공유하기 버튼 집계
+    func logInviteCodeShare(screen: String) {
+        Analytics.logEvent("invite_code_share", parameters: [
+            "screen": screen,
             "timestamp": Date().timeIntervalSince1970
         ])
     }

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Home/ViewController/HomeViewController.swift
@@ -124,6 +124,7 @@ final class HomeViewController: BaseViewController {
         viewModel.state.isPushSendInvitationVC
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, _ in
+                AnalyticsManager.shared.logInviteCodeShare(screen: "InviteSendCodeTapButton")
                 let sendInviteVC = DIContainer.shared.makeSendInviteViewController()
                 owner.navigationController?.pushViewController(sendInviteVC, animated: true)
             }


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-267

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 초대코드 공유하기 버튼 클릭 시 기록
1. AnalyticsManager에 logInviteCodeShare 함수 추가 -> 공유 버튼 클릭 이벤트를 위한 함수 생성
2. 버튼 바인딩 시 logInviteCodeShare 호출 -> 실제 버튼 클릭 시 이벤트 기록
3. Firebase 콘솔에서 invite_code_share 이벤트 집계 -> 고유 사용자 수 및 전체 대비 비율 확인


<br class="Apple-interchange-newline">

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
firebase에서는 이벤트 → invite_code_share 선택, 고유 사용자 수(unique user) 및 전체 대비 비율 확인 가능, 기간별, 화면별 분석도 가능