### PR TITLE
[Feat] STAMPIT-268 - 미션 조르기, 전달하기 비율 집계 애널리틱스

### DIFF
--- a/StampIt-Project/StampIt-Project/Presentation/Common/Manager/AnalyticsManager.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Common/Manager/AnalyticsManager.swift
@@ -52,9 +52,26 @@ final class AnalyticsManager: AnalyticsManagerProtocol {
         ])
     }
     
+    // TODO: 추후에 logEvent만 다르게 받고 버튼 집계 시 하나의 메서드로 통일할 예정
     // 초대코드 공유하기 버튼 집계
     func logInviteCodeShare(screen: String) {
         Analytics.logEvent("invite_code_share", parameters: [
+            "screen": screen,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+    
+    // 미션 조르기 사용자 비율 집계
+    func logRequestMission(screen: String) {
+        Analytics.logEvent("request_mission", parameters: [
+            "screen": screen,
+            "timestamp": Date().timeIntervalSince1970
+        ])
+    }
+
+    // 미션 전달하기 사용자 비율 집계
+    func logSendMission(screen: String) {
+        Analytics.logEvent("send_mission", parameters: [
             "screen": screen,
             "timestamp": Date().timeIntervalSince1970
         ])

--- a/StampIt-Project/StampIt-Project/Presentation/Home/Home/ViewController/HomeViewController.swift
+++ b/StampIt-Project/StampIt-Project/Presentation/Home/Home/ViewController/HomeViewController.swift
@@ -124,7 +124,7 @@ final class HomeViewController: BaseViewController {
         viewModel.state.isPushSendInvitationVC
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, _ in
-                AnalyticsManager.shared.logInviteCodeShare(screen: "InviteSendCodeTapButton")
+                AnalyticsManager.shared.logInviteCodeShare(screen: "Home_InviteSendCodeTapButton")
                 let sendInviteVC = DIContainer.shared.makeSendInviteViewController()
                 owner.navigationController?.pushViewController(sendInviteVC, animated: true)
             }
@@ -161,11 +161,17 @@ final class HomeViewController: BaseViewController {
             .disposed(by: disposeBag)
 
         homeView.didTapRequestMissionButton
+            .do(onNext: { _ in
+                AnalyticsManager.shared.logRequestMission(screen: "Home_RequestMissonTapButton")
+            })
             .map { HomeViewModel.Action.requestMission }
             .bind(to: viewModel.action)
             .disposed(by: disposeBag)
 
         homeView.didTapSendMissoinButton
+            .do(onNext: { _ in
+                AnalyticsManager.shared.logSendMission(screen: "Home_SendMissionTapButton")
+            })
             .map { HomeViewModel.Action.moveToMissionTab }
             .bind(to: viewModel.action)
             .disposed(by: disposeBag)


### PR DESCRIPTION
<!--
feat: 새로운 기능 구현
fix: 버그, 오류 해결, 코드 수정
design: 오로지 화면. 레이아웃 조정
merge: 머지, 충돌해결
refactor: 프로덕션 코드 리팩토링
comment: 필요한 주석 추가 및 변경
docs: README나 WIKI 등의 문서 개정
chore:	빌드 태스트 업데이트, 패키지 매니저를 설정하는 경우(프로덕션 코드 변경 X)
setting: 프로젝트 초기 세팅 
rename:	파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
remove:	파일을 삭제하는 작업만 수행한 경우
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  STAMPIT-268

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- AnalyticsManager
1. logRequestMission: 미션 조르기 버튼 사용자 비율 집계
2. logSendMission: 미션 전달하기 버튼 사용자 비율 집계
- HomeVC
1. HomeVC 바인딩 버튼에 각 집계 메서드를 추가 수정사항
2. 가독성을 높이기 위해 이전에 작업한 초대코드 전달하기 버튼의 스크린 이름을 변경

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
[Firebase Analytics 대시보드 > 이벤트](https://console.firebase.google.com/)에서 각 이벤트(request_mission, send_mission)의 사용자와 이벤트 발생 수를 볼 수 있습니다~
비율은 **(해당 버튼 누른 유저 수) / (전체 활성 유저 수) * 100(%)** 계산하면 되고 더 자세하게 확인하는 사항은 다음 회의 전까지 노션에 가이드로 정리해두겠습니다!